### PR TITLE
Nested Django Tag Improvements

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -63,7 +63,7 @@ class Element(object):
     def _parse_attribute_dictionary(self, attribute_dict_string):        
         attributes_dict = {}
         if (attribute_dict_string):
-            attribute_dict_string = re.sub(r'=(?P<variable>[a-zA-Z_][a-zA-Z0-9_.]+)', "'{{\g<variable>}}'", attribute_dict_string)
+            #attribute_dict_string = re.sub(r'=(?P<variable>[a-zA-Z_][a-zA-Z0-9_.]+)', "'{{\g<variable>}}'", attribute_dict_string)
             attributes_dict = eval(attribute_dict_string)
             for k, v in attributes_dict.items():
                 if k != 'id' and k != 'class':

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -63,6 +63,8 @@ class Element(object):
     def _parse_attribute_dictionary(self, attribute_dict_string):        
         attributes_dict = {}
         if (attribute_dict_string):
+            attribute_dict_string = re.sub(r'=(?P<variable>[a-zA-Z_][a-zA-Z0-9_.]+)', "'{{\g<variable>}}'", attribute_dict_string)
+            print attribute_dict_string
             attributes_dict = eval(attribute_dict_string)
             for k, v in attributes_dict.items():
                 if k != 'id' and k != 'class':

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -64,7 +64,6 @@ class Element(object):
         attributes_dict = {}
         if (attribute_dict_string):
             attribute_dict_string = re.sub(r'=(?P<variable>[a-zA-Z_][a-zA-Z0-9_.]+)', "'{{\g<variable>}}'", attribute_dict_string)
-            print attribute_dict_string
             attributes_dict = eval(attribute_dict_string)
             for k, v in attributes_dict.items():
                 if k != 'id' and k != 'class':

--- a/hamlpy/hamlpy.py
+++ b/hamlpy/hamlpy.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from nodes import RootNode, create_node
 
 class Compiler:

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -160,7 +160,13 @@ class VariableNode(ElementNode):
         return "%s%s" % (self.spaces, self._render_tag_content(tag_content))
 
 class TagNode(HamlNode):
-    self_closing = {'for':'endfor', 'if':'endif', 'block':'endblock'}
+    self_closing = {'for':'endfor',
+                    'if':'endif',
+                    'block':'endblock',
+                    'filter':'endfilter',
+                    'autoescape':'endautoescape',
+                    }
+    may_contain = {'if':'else', 'for':'empty'}
     
     def __init__(self, haml):
         HamlNode.__init__(self, haml)
@@ -178,5 +184,5 @@ class TagNode(HamlNode):
         return output
     
     def should_contain(self, node):
-        return (isinstance(node,TagNode) and node.tag_name == 'else')
+        return self.may_contain.get(self.tag_name,'') == node.tag_name
         

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -42,13 +42,6 @@ class HamlPyTest(unittest.TestCase):
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))  
           
-    def test_dictionaries_variable_substitution(self):
-        haml = "%div{'id':('itemType', =item.id)}"
-        html = "<div id='itemType_{{item.id}}'></div>"
-        hamlParser = hamlpy.Compiler()
-        result = hamlParser.process(haml)
-        self.assertEqual(html, result.replace('\n', ''))
-        
     def test_html_comments_rendered_properly(self):
         haml = '/ some comment'
         html = "<!-- some comment -->"

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -35,9 +35,16 @@ class HamlPyTest(unittest.TestCase):
         self.assertTrue("lang='en'" in result)
         self.assertTrue(result.endswith("></html>") or result.endswith("></html>\n"))
     
-    def testDictionariesSupportArraysForId(self):
+    def test_dictionaries_support_arrays_for_id(self):
         haml = "%div{'id':('itemType', '5')}"
         html = "<div id='itemType_5'></div>"
+        hamlParser = hamlpy.Compiler()
+        result = hamlParser.process(haml)
+        self.assertEqual(html, result.replace('\n', ''))  
+          
+    def test_dictionaries_variable_substitution(self):
+        haml = "%div{'id':('itemType', =item.id)}"
+        html = "<div id='itemType_{{item.id}}'></div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -98,3 +98,5 @@ class HamlPyTest(unittest.TestCase):
         eq_(html, result)
         
         
+if __name__ == '__main__':
+    unittest.main()

--- a/hamlpy/test/template_compare_test.py
+++ b/hamlpy/test/template_compare_test.py
@@ -1,8 +1,9 @@
 import codecs
+import unittest
 from nose.tools import eq_
 from hamlpy import hamlpy
 
-class TestTemplateCompare():
+class TestTemplateCompare(unittest.TestCase):
     
     def test_comparing_simple_templates(self):
         self._compare_test_files('simple')
@@ -28,6 +29,9 @@ class TestTemplateCompare():
     def test_self_closing_django(self):
         self._compare_test_files('selfClosingDjango')
         
+    def test_nested_django_tags(self):
+        self._compare_test_files('nestedDjangoTags')
+        
     def _compare_test_files(self, name):
         haml_lines = codecs.open('templates/'+name+'.hamlpy', encoding='utf-8').readlines()
         html = open('templates/'+name+'.html').read()
@@ -36,3 +40,5 @@ class TestTemplateCompare():
         parsed = haml_compiler.process_lines(haml_lines)
         eq_(parsed, html)
         
+if __name__ == '__main__':
+    unittest.main()

--- a/hamlpy/test/templates/filters.hamlpy
+++ b/hamlpy/test/templates/filters.hamlpy
@@ -1,0 +1,6 @@
+  :javascript
+    $(document).ready(function(){
+      $("#form{{form.initial.id}}").submit(form_submit);
+      // Javascript comment
+    });
+    

--- a/hamlpy/test/templates/filters.html
+++ b/hamlpy/test/templates/filters.html
@@ -1,0 +1,7 @@
+<script type="text/javascript"><![CDATA[
+    $(document).ready(function(){
+      $("#form{{form.initial.id}}").submit(form_submit);
+      // Javascript comment
+    });
+]]><script/>
+

--- a/hamlpy/test/templates/nestedDjangoTags.hamlpy
+++ b/hamlpy/test/templates/nestedDjangoTags.hamlpy
@@ -1,0 +1,10 @@
+%ul
+  - for story in story_list
+    %li= story.text
+    - if story.author_list
+      - for author in story.author_list
+        .author= author
+    - else
+      .author Anonymous
+  - empty
+    .error No stories found

--- a/hamlpy/test/templates/nestedDjangoTags.html
+++ b/hamlpy/test/templates/nestedDjangoTags.html
@@ -1,0 +1,16 @@
+<ul>
+  {% for story in story_list %}
+    <li>{{ story.text }}</li>
+    {% if story.author_list %}
+      {% for author in story.author_list %}
+        <div class='author'>{{ author }}</div>
+      {% endfor %}
+    {% else %}
+      <div class='author'>Anonymous</div>
+
+    {% endif %}
+  {% empty %}
+    <div class='error'>No stories found</div>
+
+  {% endfor %}
+</ul>

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ turns into..
 	</div>
 	
 
-The main difference is instead of interpretting Ruby, or even Python we instead can create Django Tags and Variables
+The main difference is instead of interpreting Ruby, or even Python we instead can create Django Tags and Variables
 
 	%ul#atheletes
 		- for athelete in athelete_list


### PR DESCRIPTION
Currently the following behaves unexpectedly:
    - if foo
      - for bar in baz
        #output stuff
    - else
      #output otherstuff

by outputting:

```
{% if foo %}
  {% for bar in baz %}
    <div id='output'>stuff</div>
{% else %}
  <div id='output'>otherstuff</div>

  {% endfor %}
{% endif %}
```

now it will output:

```
{% if foo %}
  {% for bar in baz %}
    <div id='output'>stuff</div>
  {% endfor %}
{% else %}
  <div id='output'>otherstuff</div>

{% endif %}
```

as well as giving autoescape, filter and for..empty the self closing behavior.
