### PR TITLE
Added support for Ruby-style inline variables in HamlPy

### DIFF
--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -141,6 +141,7 @@ class ElementNode(HamlNode):
             current_tag_content = ''
         if self.django_variable:
             current_tag_content = "{{ " + current_tag_content.strip() + " }}"
+        current_tag_content = re.sub(r'#\{([a-zA-Z0-9\.\_]+)\}', r'{{ \1 }}', current_tag_content)
         return current_tag_content
 
 

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -99,10 +99,10 @@ class HamlPyTest(unittest.TestCase):
         
     def test_inline_variables_are_parsed_correctly(self):
         haml = "%h1 Hello, #{name}, how are you?"
-        html = "<h1>Hello, {{ name }}, how are you?</h1>"
+        html = "<h1>Hello, {{ name }}, how are you?</h1>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
-        self.assertEqual(html, result)
+        eq_(html, result)
         
 if __name__ == '__main__':
     unittest.main()

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -97,6 +97,12 @@ class HamlPyTest(unittest.TestCase):
         result = hamlParser.process(haml)
         eq_(html, result)
         
+    def test_inline_variables_are_parsed_correctly(self):
+        haml = "%h1 Hello, #{name}, how are you?"
+        html = "<h1>Hello, {{ name }}, how are you?</h1>"
+        hamlParser = hamlpy.Compiler()
+        result = hamlParser.process(haml)
+        self.assertEqual(html, result)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi There,

I've added support for Ruby-style inline variables. Now, `%h1 Hi, #{person.name}` will be replaced with `<h1>Hi, {{ person.name }}</h1>`. Great job on HamlPy, it's fantastic!

Jamie
