### PR TITLE
Nested plaintext bugfix, auto-closing script tags, with/endwith support

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -4,13 +4,13 @@ import re
 class Element(object):
     """contains the pieces of an element and can populate itself from haml element text"""
     
-    self_closing_tags = ('meta', 'img', 'link', 'script', 'br', 'hr')
+    self_closing_tags = ('meta', 'img', 'link', 'br', 'hr')
 
     ELEMENT = '%'
     ID = '#'
     CLASS = '.'
 
-    HAML_REGEX = re.compile(r"(?P<tag>%\w+)?(?P<id>#\w*)?(?P<class>\.[\w\.-]*)*(?P<attributes>\{.*\})?(?P<selfclose>/)?(?P<django>=)?(?P<inline>[^\w\.#\{].*)?")
+    HAML_REGEX = re.compile(r"(?P<tag>%\w+)?(?P<id>#[\w-]*)?(?P<class>\.[\w\.-]*)*(?P<attributes>\{.*\})?(?P<selfclose>/)?(?P<django>=)?(?P<inline>[^\w\.#\{].*)?")
     
     def __init__(self, haml):
         self.haml = haml

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -95,7 +95,7 @@ class HamlNode(RootNode):
         
     
     def render(self):
-        return "%s%s" % (self.spaces, self.haml)
+        return "".join([self.spaces, self.haml, '\n', self.render_internal_nodes()])
 
 
 class ElementNode(HamlNode):

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -185,8 +185,9 @@ class TagNode(HamlNode):
                     'block':'endblock',
                     'filter':'endfilter',
                     'autoescape':'endautoescape',
+                    'with':'endwith',
                     }
-    may_contain = {'if':'else', 'for':'empty'}
+    may_contain = {'if':'else', 'for':'empty', 'with':'with'}
     
     def __init__(self, haml):
         HamlNode.__init__(self, haml)

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -72,10 +72,7 @@ class RootNode:
         return self.render_internal_nodes()
     
     def render_internal_nodes(self):
-        result = ''
-        for node in self.internal_nodes:
-            result += ('%s\n') % node.render()
-        return result
+        return ''.join([node.render() for node in self.internal_nodes])
     
     def has_internal_nodes(self):
         return len(self.internal_nodes) > 0
@@ -95,7 +92,10 @@ class HamlNode(RootNode):
         
     
     def render(self):
-        return "".join([self.spaces, self.haml, '\n', self.render_internal_nodes()])
+        if self.has_internal_nodes():
+          return ''.join([self.spaces, self.haml, '\n', self.render_internal_nodes()])
+        else:
+          return ''.join([self.spaces, self.haml,'\n'])
 
 
 class ElementNode(HamlNode):
@@ -128,9 +128,9 @@ class ElementNode(HamlNode):
         content = self._render_tag_content(element.inline_content)
         
         if element.self_close and not content:
-            result += " />"
+            result += " />\n"
         else:
-            result += ">%s</%s>" % (content, element.tag)
+            result += ">%s</%s>\n" % (content, element.tag)
         
         return result
     
@@ -158,7 +158,7 @@ class CommentNode(HamlNode):
         else:
             content = self.haml + ' '
         
-        return "<!-- %s-->" % content
+        return "<!-- %s-->\n" % content
 
 
 class HamlCommentNode(HamlNode):
@@ -176,7 +176,7 @@ class VariableNode(ElementNode):
     
     def render(self):
         tag_content = self.haml.lstrip(VARIABLE)
-        return "%s%s" % (self.spaces, self._render_tag_content(tag_content))
+        return "%s%s\n" % (self.spaces, self._render_tag_content(tag_content))
 
 
 class TagNode(HamlNode):
@@ -201,7 +201,7 @@ class TagNode(HamlNode):
         internal = self.render_internal_nodes()
         output = "%s{%% %s %%}\n%s" % (self.spaces, self.tag_statement, internal)
         if (self.tag_name in self.self_closing.keys()):
-            output += '%s{%% %s %%}' % (self.spaces, self.self_closing[self.tag_name])
+            output += '%s{%% %s %%}\n' % (self.spaces, self.self_closing[self.tag_name])
         return output
     
     def should_contain(self, node):
@@ -225,7 +225,7 @@ class JavascriptFilterNode(FilterNode):
     def render(self):
         output = '<script type=\'text/javascript\'>\n// <![CDATA[\n'
         output += "".join([node.raw_haml for node in self.internal_nodes])
-        output += '// ]]>\n</script>'
+        output += '// ]]>\n</script>\n'
         return output
         
         
@@ -233,6 +233,6 @@ class CssFilterNode(FilterNode):
     def render(self):
         output = '<style type=\'text/css\'>\n/*<![CDATA[*/\n'
         output += "".join([node.raw_haml for node in self.internal_nodes])
-        output += '/*]]>*/\n</style>'
+        output += '/*]]>*/\n</style>\n'
         return output
         

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -72,7 +72,7 @@ class HamlPyTest(unittest.TestCase):
         
     def test_if_else_django_tags_render(self):
         haml = '- if something\n   %p hello\n- else\n   %p goodbye'
-        html = '{% if something %}\n   <p>hello</p>\n{% else %}\n   <p>goodbye</p>\n\n{% endif %}\n'
+        html = '{% if something %}\n   <p>hello</p>\n{% else %}\n   <p>goodbye</p>\n{% endif %}\n'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
@@ -107,6 +107,20 @@ class HamlPyTest(unittest.TestCase):
     def test_inline_variables_with_special_characters_are_parsed_correctly(self):
         haml = "%h1 Hello, #{person.name}, how are you?"
         html = "<h1>Hello, {{ person.name }}, how are you?</h1>\n"
+        hamlParser = hamlpy.Compiler()
+        result = hamlParser.process(haml)
+        eq_(html, result)
+        
+    def test_plain_text(self):
+        haml = "This should be plain text\n    This should be indented"
+        html = "This should be plain text\n    This should be indented\n"
+        hamlParser = hamlpy.Compiler()
+        result = hamlParser.process(haml)
+        eq_(html, result)   
+             
+    def test_plain_text_with_indenting(self):
+        haml = "This should be plain text"
+        html = "This should be plain text\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)

--- a/hamlpy/test/templates/djangoCombo.html
+++ b/hamlpy/test/templates/djangoCombo.html
@@ -1,5 +1,4 @@
 {% extends "base_generic.html" %}
-
 {% block title %}
   {{ section.title }}
 {% endblock %}

--- a/hamlpy/test/templates/hamlComments.html
+++ b/hamlpy/test/templates/hamlComments.html
@@ -1,8 +1,6 @@
 <div>
   <div>
-
     This will
-
   </div>
   <div>More</div>
 </div>

--- a/hamlpy/test/templates/nestedDjangoTags.html
+++ b/hamlpy/test/templates/nestedDjangoTags.html
@@ -7,10 +7,8 @@
       {% endfor %}
     {% else %}
       <div class='author'>Anonymous</div>
-
     {% endif %}
   {% empty %}
     <div class='error'>No stories found</div>
-
   {% endfor %}
 </ul>

--- a/hamlpy/test/templates/selfClosingTags.hamlpy
+++ b/hamlpy/test/templates/selfClosingTags.hamlpy
@@ -4,6 +4,5 @@
 %meta{'content':'text/html'}
 %img
 %link
-%script
 %br
 %hr

--- a/hamlpy/test/templates/selfClosingTags.html
+++ b/hamlpy/test/templates/selfClosingTags.html
@@ -4,6 +4,5 @@
 <meta content='text/html' />
 <img />
 <link />
-<script />
 <br />
 <hr />


### PR DESCRIPTION
Currently the following behaves unexpectedly:
    Plain text
        Nested plain text

The nested plain text node gets added to the first plain text node and when the first node is rendered it never bothers to render its internal nodes. This is fixed in 59ff6ba946cff590198a46fa53fb2434e6594b6f. That change broke a few tests and had some unexpected whitespace issues, so I went through the various nodes/tests to try to make a more consistent rule. 

After c6bfb5fa10be6245c25e14786022d50cd5118182, every node's render method should end with a new line. This gives output formatted almost identically to the input, with the exception that empty newlines are swallowed. I'm not sure why this is, but the result seems nicer than the old way which resulted in some odd extraneous newlines.

In 1612ef979176cab2a38560925def12a0cff47578 I added hyphen to the regex for identifying CSS classes. It's a valid character and my designer used it in a few places. The commit also removed script from the list of autoclosing tags as empty script tags break some browsers (including the latest version of Chrome I am using, 8.0.552.231. http://stackoverflow.com/questions/69913/why-dont-self-closing-script-tags-work

Finally, I added with/endwith support (364e869ef58a62d3f09ca2a0551c0e15dda69a8a). Withs can be nested at the same level of indentation, so you can do
    - with foo.expensive.bar as bar
    - with foo.other_expensive.baz as baz
        The #{bar} is #{baz}
and it will be rendered as 
    {% with foo.expensive.bar as bar %}
    {% with foo.other_expensive.baz as baz %}
        The {{bar}} is {{baz}}
    {% endwith %}
    {% endwith %}
I apologize that this is all bundled into one large pull request, but I made a bunch of the changes as I found the bugs and didn't have the git chops to quickly get my repo into a state where the pull request would be clean.
