### PR TITLE
Support multiline attributes

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -1,5 +1,11 @@
 import re
 
+MULTILINE_ATTR_ELEMENT_REGEX = re.compile(r"""
+(?P<tag>%\w+(\:\w+)?)?
+(?P<id>\#[\w-]*)?
+(?P<class>\.[\w\.-]*)*
+(?P<attribute_start>\{[^\}]+$)
+""", re.X)
 
 class Element(object):
     """contains the pieces of an element and can populate itself from haml element text"""
@@ -10,8 +16,16 @@ class Element(object):
     ID = '#'
     CLASS = '.'
 
-    HAML_REGEX = re.compile(r"(?P<tag>%\w+(\:\w+)?)?(?P<id>#[\w-]*)?(?P<class>\.[\w\.-]*)*(?P<attributes>\{.*\})?(?P<selfclose>/)?(?P<django>=)?(?P<inline>[^\w\.#\{].*)?")
-    
+    HAML_REGEX = re.compile(r"""
+    (?P<tag>%\w+(\:\w+)?)?
+    (?P<id>\#[\w-]*)?
+    (?P<class>\.[\w\.-]*)*
+    (?P<attributes>\{.*\})?
+    (?P<selfclose>/)?
+    (?P<django>=)?
+    (?P<inline>[^\w\.#\{].*)?
+    """, re.X|re.MULTILINE|re.DOTALL)
+
     def __init__(self, haml):
         self.haml = haml
         self.tag = None
@@ -60,9 +74,10 @@ class Element(object):
                 text += '_'+one_id
         return text
 
-    def _parse_attribute_dictionary(self, attribute_dict_string):        
+    def _parse_attribute_dictionary(self, attribute_dict_string):
         attributes_dict = {}
         if (attribute_dict_string):
+            attribute_dict_string = attribute_dict_string.replace('\n', ' ')
             try:
                 #attribute_dict_string = re.sub(r'=(?P<variable>[a-zA-Z_][a-zA-Z0-9_.]+)', "'{{\g<variable>}}'", attribute_dict_string)
                 # converting all allowed attributes to python dictionary style

--- a/hamlpy/hamlpy.py
+++ b/hamlpy/hamlpy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from elements import MULTILINE_ATTR_ELEMENT_REGEX
 from nodes import RootNode, create_node
 
 class Compiler:
@@ -9,8 +10,14 @@ class Compiler:
         
     def process_lines(self, haml_lines):
         root = RootNode()
-        for line in haml_lines:
-            haml_node = create_node(line)
+        line_iter = iter(haml_lines)
+        for line in line_iter:
+            node_lines = line
+            if MULTILINE_ATTR_ELEMENT_REGEX.match(line.strip()):
+                while '}' not in line:
+                    line = line_iter.next()
+                    node_lines += line
+            haml_node = create_node(node_lines)
             root.add_node(haml_node)
         return root.render()
 

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -83,5 +83,10 @@ class TestElement(object):
         def test_grabs_inline_tag_content(self):
             sut = Element("%div Some Text")
             eq_(sut.inline_content, 'Some Text')
-        
-    
+            
+        def test_multiline_attributes(self):
+            sut = Element("""%link{'rel': 'stylesheet', 'type': 'text/css',
+                'href': '/long/url/to/stylesheet/resource.css'}""")
+            assert "href='/long/url/to/stylesheet/resource.css'" in sut.attributes
+            assert "type='text/css'" in sut.attributes
+            assert "rel='stylesheet'" in sut.attributes

--- a/reference.md
+++ b/reference.md
@@ -74,6 +74,11 @@ is compiled to:
 
 	<html xmlns='http://www.w3.org/1999/xhtml' xml:lang='en' lang='en'></html>
 
+Long attribute dictionaries can be separated into multiple lines:
+
+    %script{'type': 'text/javascript', 'charset': 'utf-8', 
+            'href': '/long/url/to/javascript/resource.js'}
+
 #### 'class' and 'id' attributes
 
 The 'class' and 'id' attributes can also be specified as a Python tuple whose elements will be joined together.  A 'class' tuple will be joined with " " and an 'id' tuple is joined with "_".  For example:


### PR DESCRIPTION
When using an attribute dictionary on an element, it's easy to end up with a very long line. These commits allow attribute dictionaries to be split across multiple lines, similar to the real Python syntax.
