### PR TITLE
Some template tags that are included in django (1.3) were missing

### DIFF
--- a/hamlpy/__init__.py
+++ b/hamlpy/__init__.py
@@ -1,0 +1,1 @@
+import templatize

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -230,6 +230,11 @@ class TagNode(HamlNode):
                     'filter':'endfilter',
                     'autoescape':'endautoescape',
                     'with':'endwith',
+                    'blocktrans': 'endblocktrans',
+                    'spaceless': 'endspaceless',
+                    'comment': 'endcomment',
+                    'cache': 'endcache',
+                    'localize': 'endlocalize',
                     }
     may_contain = {'if':'else', 
                    'ifchanged':'else',

--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -1,0 +1,19 @@
+"""
+This module decorates the django templatize function to parse haml templates
+before the translation utility extracts tags from it.
+"""
+
+from django.utils.translation import trans_real
+import hamlpy
+
+
+def decorate_templatize(func):
+	def templatize(src, origin=None):
+		hamlParser = hamlpy.Compiler()
+		html = hamlParser.process(src)
+		return func(html, origin)
+	
+	return templatize
+
+trans_real.templatize = decorate_templatize(trans_real.templatize)
+

--- a/readme.md
+++ b/readme.md
@@ -34,13 +34,13 @@ The main difference is instead of interpreting Ruby, or even Python we instead c
 
 	%ul#atheletes
 		- for athelete in athelete_list
-			%li.athelete= athelete.name
+			%li.athelete{'id': 'athelete_{{ athelete.pk }}'}= athelete.name
 
 turns into..
 
 	<ul id='atheletes'>
 		{% for athelete in athelete_list %}
-			<li class='athelete'>{{ athelete.name }}</li>
+			<li class='athelete' id='athelete_{{ athelete.pk }}'>{{ athelete.name }}</li>
 		{% endfor %}
 	</ul>
 	


### PR DESCRIPTION
I've added some template tags that have end\* counterparts (blocktrans, comment, spaceless, etc.)
