### PR TITLE
add pycharm and eclipse project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 dist
 build
 hamlpy.egg-info
+/.idea/
+.project
+.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ hamlpy.egg-info
 /.idea/
 .project
 .pydevproject
+.DS_Store


### PR DESCRIPTION
Since .gitignore is in repo, it is better to ignore some common files...
