### PR TITLE
Empty HTML attributes like itemscope

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -81,7 +81,7 @@ class Element(object):
                     if k != 'id' and k != 'class':
                         if v.lower() in ("yes", "true", "t", "1"):
                             self.attributes += "%s " % (k,)
-                        if isinstance(v, int) or isinstance(v, float):
+                        elif isinstance(v, int) or isinstance(v, float):
                             self.attributes += "%s='%s' " % (k, v)
                         else:
                             v = v.decode('utf-8')

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -79,6 +79,8 @@ class Element(object):
                 attributes_dict = eval(attribute_dict_string)
                 for k, v in attributes_dict.items():
                     if k != 'id' and k != 'class':
+                        if v.lower() in ("yes", "true", "t", "1"):
+                            self.attributes += "%s " % (k,)
                         if isinstance(v, int) or isinstance(v, float):
                             self.attributes += "%s='%s' " % (k, v)
                         else:


### PR DESCRIPTION
I have listed the entire discussion about enabling empty attributes in issue #58. 
Examples of this are 'itemscope'. 
