### PR TITLE
#74 Fix

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -26,10 +26,10 @@ class Element(object):
     #Single and double quote regexes from: http://stackoverflow.com/a/5453821/281469
     _SINGLE_QUOTE_STRING_LITERAL_REGEX = r"'([^'\\]*(?:\\.[^'\\]*)*)'"
     _DOUBLE_QUOTE_STRING_LITERAL_REGEX = r'"([^"\\]*(?:\\.[^"\\]*)*)"'
-    _ATTIBUTE_VALUE_REGEX = r'(?P<val>\d+|None(?![A-Za-z0-9_])|%s|%s)'%(_SINGLE_QUOTE_STRING_LITERAL_REGEX, _DOUBLE_QUOTE_STRING_LITERAL_REGEX)
+    _ATTRIBUTE_VALUE_REGEX = r'(?P<val>\d+|None(?![A-Za-z0-9_])|%s|%s)'%(_SINGLE_QUOTE_STRING_LITERAL_REGEX, _DOUBLE_QUOTE_STRING_LITERAL_REGEX)
 
     RUBY_HAML_REGEX = re.compile(r'(:|\")%s(\"|) =>'%(_ATTRIBUTE_KEY_REGEX))
-    ATTRIBUTE_REGEX = re.compile(r'(?P<pre>\{\s*|,\s*)%s:\s*%s'%(_ATTRIBUTE_KEY_REGEX, _ATTIBUTE_VALUE_REGEX))
+    ATTRIBUTE_REGEX = re.compile(r'(?P<pre>\{\s*|,\s*)%s:\s*%s'%(_ATTRIBUTE_KEY_REGEX, _ATTRIBUTE_VALUE_REGEX))
     DJANGO_VARIABLE_REGEX = re.compile(r'^\s*=\s(?P<variable>[a-zA-Z_][a-zA-Z0-9_-]*)\s*$')
 
 

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -4,6 +4,24 @@ from hamlpy.elements import Element
 
 class TestElement(object):
 
+        def test_attribute_value_not_quoted_when_looks_like_key(self):
+            sut = Element('')
+            s1 = sut._parse_attribute_dictionary('''{name:"viewport", content:"width:device-width, initial-scale:1, minimum-scale:1, maximum-scale:1"}''')
+            eq_(s1['content'], 'width:device-width, initial-scale:1, minimum-scale:1, maximum-scale:1')
+            eq_(s1['name'], 'viewport')
+
+            sut = Element('')
+            s1 = sut._parse_attribute_dictionary('''{style:"a:x, b:'y', c:1, e:3"}''')
+            eq_(s1['style'], "a:x, b:'y', c:1, e:3")
+
+            sut = Element('')
+            s1 = sut._parse_attribute_dictionary('''{style:"a:x, b:'y', c:1, d:\\"dk\\", e:3"}''')
+            eq_(s1['style'], '''a:x, b:'y', c:1, d:"dk", e:3''')
+
+            sut = Element('')
+            s1 = sut._parse_attribute_dictionary('''{style:'a:x, b:\\'y\\', c:1, d:"dk", e:3'}''')
+            eq_(s1['style'], '''a:x, b:'y', c:1, d:"dk", e:3''')
+
         def test_dashes_work_in_attribute_quotes(self):
             sut = Element('')
             s1 = sut._parse_attribute_dictionary('''{"data-url":"something", "class":"blah"}''')


### PR DESCRIPTION
I wanted to get rid of the regex but the alternative of parsing the attribute string manually was slower and more complicated. 

Moved the regular expressions to the top of the file to avoid recompiling them each time the function is called. Ran it against the hotshot profiler and it was too slow for my liking. Also split them up to make it more readable.
