### PR TITLE
Django variables in attributes containing periods.

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -30,7 +30,7 @@ class Element(object):
 
     RUBY_HAML_REGEX = re.compile(r'(:|\")%s(\"|) =>'%(_ATTRIBUTE_KEY_REGEX))
     ATTRIBUTE_REGEX = re.compile(r'(?P<pre>\{\s*|,\s*)%s:\s*%s'%(_ATTRIBUTE_KEY_REGEX, _ATTRIBUTE_VALUE_REGEX))
-    DJANGO_VARIABLE_REGEX = re.compile(r'^\s*=\s(?P<variable>[a-zA-Z_][a-zA-Z0-9_-]*)\s*$')
+    DJANGO_VARIABLE_REGEX = re.compile(r'^\s*=\s(?P<variable>[a-zA-Z_][a-zA-Z0-9._-]*)\s*$')
 
 
     def __init__(self, haml):

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -52,6 +52,20 @@ class TestElement(object):
 
             eq_(sut.attributes, "a='something' c='2' b d='{{some_var}}'")
 
+        def test_django_variable_in_attribute_detected (self):
+            key = 'something'
+            var_name = 'some_variable'
+            sut = Element('''%%a{'%s' : '= %s'}''' % (key, var_name))
+            eq_ (sut.attributes_dict[key], '{{%s}}' % var_name)
+
+        def test_django_variable_with_dots_in_attribute_detected (self):
+            key = 'something'
+            var_name = 'some_variable.sub_var.more_sub'
+            sut = Element('''%%a{'%s' : '= %s'}''' % (key, var_name))
+            eq_ (sut.attributes_dict[key], '{{%s}}' % var_name)
+
+
+
         def test_pulls_tag_name_off_front(self):
             sut = Element('%div.class')
             eq_(sut.tag, 'div')


### PR DESCRIPTION
previously the following line:
  %a{'href' : '= blogpost.url'}

would not evaluate to
   &lt;a href='{{blogpost.url}}' &gt;

I have modified the DJANGO_VARIABLE_REGEX to include periods, and added a couple of tests.
