### PR TITLE
Fix setup.py to install pygments dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ setup(name='hamlpy',
       keywords = 'haml django converter',
       url = 'http://github.com/jessemiller/HamlPy',
       license = 'MIT',
-      requires = [
-        'django',
+      install_requires = [
         'pygments'
       ],
       entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='hamlpy',
       url = 'http://github.com/jessemiller/HamlPy',
       license = 'MIT',
       install_requires = [
-        'pygments'
+          'Django',
+          'pygments'
       ],
       entry_points = {
           'console_scripts' : ['hamlpy = hamlpy.hamlpy:convert_files',


### PR DESCRIPTION
This branch make the installation to automaticly install pygments when we `pip install hamlpy`.
