### PR TITLE
--attr-wrapper option for command line and HAMLPY_ATTR_WRAPPER setting for Django

### DIFF
--- a/hamlpy/hamlpy.py
+++ b/hamlpy/hamlpy.py
@@ -6,12 +6,18 @@ import sys
 VALID_EXTENSIONS=['haml', 'hamlpy']
 
 class Compiler:
-    def process(self, raw_text, options=None):
-        split_text = raw_text.split('\n')
-        return self.process_lines(split_text, options)
 
-    def process_lines(self, haml_lines, options=None):
-        root = RootNode()
+    def __init__(self, options_dict=None):
+        options_dict = options_dict or {}
+        self.debug_tree = options_dict.pop('debug_tree', False)
+        self.options_dict = options_dict
+
+    def process(self, raw_text):
+        split_text = raw_text.split('\n')
+        return self.process_lines(split_text)
+
+    def process_lines(self, haml_lines):
+        root = RootNode(**self.options_dict)
         line_iter = iter(haml_lines)
 
         haml_node=None
@@ -36,8 +42,8 @@ class Compiler:
                 haml_node = create_node(node_lines)
                 if haml_node:
                     root.add_node(haml_node)
-                
-        if options and options.debug_tree:
+
+        if self.options_dict and self.options_dict.get('debug_tree'):
             return root.debug_tree()
         else:
             return root.render()
@@ -47,19 +53,27 @@ def convert_files():
     import codecs
 
     parser = OptionParser()
-    parser.add_option("-d", "--debug-tree", dest="debug_tree",
-    action="store_true", help="Print the generated tree instead of the HTML")
+    parser.add_option(
+        "-d", "--debug-tree", dest="debug_tree",
+        action="store_true",
+        help="Print the generated tree instead of the HTML")
+    parser.add_option(
+        "--attr-wrapper", dest="attr_wrapper",
+        type="choice", choices=('"', "'"), default="'",
+        action="store",
+        help="The character that should wrap element attributes. "
+        "This defaults to ' (an apostrophe).")
     (options, args) = parser.parse_args()
 
     if len(args) < 1:
         print "Specify the input file as the first argument."
-    else: 
+    else:
         infile = args[0]
         haml_lines = codecs.open(infile, 'r', encoding='utf-8').read().splitlines()
 
-        compiler = Compiler()
-        output = compiler.process_lines(haml_lines, options=options)
-        
+        compiler = Compiler(options.__dict__)
+        output = compiler.process_lines(haml_lines)
+
         if len(args) == 2:
             outfile = codecs.open(args[1], 'w', encoding='utf-8')
             outfile.write(output)

--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -35,7 +35,7 @@ class StoreNameValueTagPair(argparse.Action):
         for item in values:
             n, v = item.split(':')
             tags[n] = v
-        
+
         setattr(namespace, 'tags', tags)
 
 arg_parser = argparse.ArgumentParser()
@@ -46,6 +46,7 @@ arg_parser.add_argument('-r', '--refresh', metavar = 'S', default = Options.CHEC
 arg_parser.add_argument('input_dir', help = 'Folder to watch', type = str)
 arg_parser.add_argument('output_dir', help = 'Destination folder', type = str, nargs = '?')
 arg_parser.add_argument('--tag', help = 'Add self closing tag. eg. --tag macro:endmacro', type = str, nargs = 1, action = StoreNameValueTagPair)
+arg_parser.add_argument('--attr-wrapper', dest='attr_wrapper', type=str, choices=('"', "'"), default="'", action='store', help="The character that should wrap element attributes. This defaults to ' (an apostrophe).")
 
 def watched_extension(extension):
     """Return True if the given extension is one of the watched extensions"""
@@ -58,35 +59,41 @@ def watch_folder():
     """Main entry point. Expects one or two arguments (the watch folder + optional destination folder)."""
     argv = sys.argv[1:] if len(sys.argv) > 1 else []
     args = arg_parser.parse_args(sys.argv[1:])
-    
-    input_folder = os.path.realpath(args.input_dir)
-    if not args.output_dir:
+    args_dict = args.__dict__
+
+    input_folder = os.path.realpath(args_dict.pop('input_dir'))
+    output_folder = args_dict.pop('output_dir', None)
+    refresh_interval = args_dict.pop('refresh')
+    if not output_folder:
         output_folder = input_folder
     else:
-        output_folder = os.path.realpath(args.output_dir)
-    
-    if args.verbose:
+        output_folder = os.path.realpath(output_folder )
+
+    if args_dict.pop('verbose'):
         Options.VERBOSE = True
-        print "Watching {} at refresh interval {} seconds".format(input_folder, args.refresh)
-    
-    if args.extension:
-        Options.OUTPUT_EXT = args.extension
-    
-    if args.tags:
-        hamlpynodes.TagNode.self_closing.update(args.tags)
-    
-    if args.input_extension:
-        hamlpy.VALID_EXTENSIONS += args.input_extension
-    
+        print "Watching {} at refresh interval {} seconds".format(input_folder, refresh_interval)
+
+    extension = args_dict.pop('extension')
+    if extension:
+        Options.OUTPUT_EXT = extension
+
+    tags = args_dict.pop('tag')
+    if tags:
+        hamlpynodes.TagNode.self_closing.update(tags)
+
+    input_extension = args_dict.pop('input_extension')
+    if input_extension:
+        hamlpy.VALID_EXTENSIONS += input_extension
+
     while True:
         try:
-            _watch_folder(input_folder, output_folder)
-            time.sleep(args.refresh)
+            _watch_folder(input_folder, output_folder, args_dict)
+            time.sleep(refresh_interval)
         except KeyboardInterrupt:
             # allow graceful exit (no stacktrace output)
             sys.exit(0)
 
-def _watch_folder(folder, destination):
+def _watch_folder(folder, destination, args_dict):
     """Compares "modified" timestamps against the "compiled" dict, calls compiler
     if necessary."""
     for dirpath, dirnames, filenames in os.walk(folder):
@@ -96,23 +103,23 @@ def _watch_folder(folder, destination):
                 fullpath = os.path.join(dirpath, filename)
                 subfolder = os.path.relpath(dirpath, folder)
                 mtime = os.stat(fullpath).st_mtime
-                
+
                 # Create subfolders in target directory if they don't exist
                 compiled_folder = os.path.join(destination, subfolder)
                 if not os.path.exists(compiled_folder):
                     os.makedirs(compiled_folder)
-                
+
                 compiled_path = _compiled_path(compiled_folder, filename)
                 if (not fullpath in compiled or
                     compiled[fullpath] < mtime or
                     not os.path.isfile(compiled_path)):
-                    compile_file(fullpath, compiled_path)
+                    compile_file(fullpath, compiled_path, args_dict)
                     compiled[fullpath] = mtime
 
 def _compiled_path(destination, filename):
     return os.path.join(destination, filename[:filename.rfind('.')] + Options.OUTPUT_EXT)
 
-def compile_file(fullpath, outfile_name):
+def compile_file(fullpath, outfile_name, args_dict):
     """Calls HamlPy compiler."""
     if Options.VERBOSE:
         print '%s %s -> %s' % (strftime("%H:%M:%S", gmtime()), fullpath, outfile_name)
@@ -120,7 +127,7 @@ def compile_file(fullpath, outfile_name):
         if Options.DEBUG:
             print "Compiling %s -> %s" % (fullpath, outfile_name)
         haml_lines = codecs.open(fullpath, 'r', encoding = 'utf-8').read().splitlines()
-        compiler = hamlpy.Compiler()
+        compiler = hamlpy.Compiler(args_dict)
         output = compiler.process_lines(haml_lines)
         outfile = codecs.open(outfile_name, 'w', encoding = 'utf-8')
         outfile.write(output)

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -44,56 +44,56 @@ def create_node(haml_line):
 
     if len(stripped_line) == 0:
         return None
-    
+
     if re.match(INLINE_VARIABLE, stripped_line) or re.match(ESCAPED_INLINE_VARIABLE, stripped_line):
         return PlaintextNode(haml_line)
-    
+
     if stripped_line[0] == HAML_ESCAPE:
         return PlaintextNode(haml_line)
-        
+
     if stripped_line.startswith(DOCTYPE):
         return DoctypeNode(haml_line)
 
     if stripped_line[0] in ELEMENT_CHARACTERS:
         return ElementNode(haml_line)
-    
+
     if stripped_line[0:len(CONDITIONAL_COMMENT)] == CONDITIONAL_COMMENT:
         return ConditionalCommentNode(haml_line)
-        
+
     if stripped_line[0] == HTML_COMMENT:
         return CommentNode(haml_line)
-    
+
     for comment_prefix in HAML_COMMENTS:
         if stripped_line.startswith(comment_prefix):
             return HamlCommentNode(haml_line)
-    
+
     if stripped_line[0] == VARIABLE:
         return VariableNode(haml_line)
 
     if stripped_line[0] == TAG:
         return TagNode(haml_line)
-    
+
     if stripped_line == JAVASCRIPT_FILTER:
         return JavascriptFilterNode(haml_line)
-    
+
     if stripped_line in COFFEESCRIPT_FILTERS:
         return CoffeeScriptFilterNode(haml_line)
-        
+
     if stripped_line == CSS_FILTER:
         return CssFilterNode(haml_line)
-    
+
     if stripped_line == STYLUS_FILTER:
         return StylusFilterNode(haml_line)
 
     if stripped_line == PLAIN_FILTER:
         return PlainFilterNode(haml_line)
-        
+
     if stripped_line == PYTHON_FILTER:
         return PythonFilterNode(haml_line)
-    
+
     if stripped_line == CDATA_FILTER:
         return CDataFilterNode(haml_line)
-		
+
     if stripped_line == PYGMENTS_FILTER:
         return PygmentsFilterNode(haml_line)
 
@@ -123,7 +123,7 @@ class TreeNode(object):
         self.children.append(child)
 
 class RootNode(TreeNode):
-    def __init__(self):
+    def __init__(self, attr_wrapper="'"):
         TreeNode.__init__(self)
         self.indentation = -2
         # Number of empty lines to render after node
@@ -134,6 +134,14 @@ class RootNode(TreeNode):
         self.after = ''
         # Indicates that a node does not render anything (for whitespace removal)
         self.empty_node = False
+
+        # Options
+        self.attr_wrapper = attr_wrapper
+
+    def add_child(self, child):
+        '''Add child node, and copy all options to it'''
+        super(RootNode, self).add_child(child)
+        child.attr_wrapper = self.attr_wrapper
 
     def render(self):
         # Render (sets self.before and self.after)
@@ -162,7 +170,7 @@ class RootNode(TreeNode):
     def _render_children(self):
         for child in self.children:
             child._render()
-            
+
     def _post_render(self):
         for child in self.children:
             child._post_render()
@@ -176,17 +184,17 @@ class RootNode(TreeNode):
             output.append(child.after)
         output.append(self.after)
         return ''.join(output)
-    
+
     def add_node(self, node):
         if (self._should_go_inside_last_node(node)):
             self.children[-1].add_node(node)
         else:
             self.add_child(node)
-    
+
     def _should_go_inside_last_node(self, node):
         return len(self.children) > 0 and (node.indentation > self.children[-1].indentation
             or (node.indentation == self.children[-1].indentation and self.children[-1].should_contain(node)))
-    
+
     def should_contain(self, node):
         return False
 
@@ -204,7 +212,7 @@ class RootNode(TreeNode):
     def __repr__(self):
         return '(%s)' % (self.__class__)
 
-class HamlNode(RootNode):   
+class HamlNode(RootNode):
     def __init__(self, haml):
         RootNode.__init__(self)
         self.haml = haml.strip()
@@ -242,7 +250,7 @@ class ElementNode(HamlNode):
         self.django_variable = False
 
     def _render(self):
-        self.element = Element(self.haml)
+        self.element = Element(self.haml, self.attr_wrapper)
         self.django_variable = self.element.django_variable
         self.before = self._render_before(self.element)
         self.after = self._render_after(self.element)
@@ -252,9 +260,9 @@ class ElementNode(HamlNode):
         '''Render opening tag and inline content'''
         start = ["%s<%s" % (self.spaces, element.tag)]
         if element.id:
-            start.append(" id='%s'" % self.replace_inline_variables(element.id))
+            start.append(" id=%s" % self.element.attr_wrap(self.replace_inline_variables(element.id)))
         if element.classes:
-            start.append(" class='%s'" % self.replace_inline_variables(element.classes))
+            start.append(" class=%s" % self.element.attr_wrap(self.replace_inline_variables(element.classes)))
         if element.attributes:
             start.append(' ' + self.replace_inline_variables(element.attributes))
 
@@ -327,7 +335,7 @@ class ElementNode(HamlNode):
                 self.parent.after = self.parent.after.lstrip()
                 self.parent.newlines = 0
 
-        super(ElementNode, self)._post_render()    
+        super(ElementNode, self)._post_render()
 
     def _render_inline_content(self, inline_content):
         if inline_content == None or len(inline_content) == 0:
@@ -338,8 +346,8 @@ class ElementNode(HamlNode):
             return content
         else:
             return self.replace_inline_variables(inline_content)
-        
-class CommentNode(HamlNode):    
+
+class CommentNode(HamlNode):
     def _render(self):
         self.after = "-->\n"
         if self.children:
@@ -357,7 +365,7 @@ class ConditionalCommentNode(HamlNode):
         else:
             content = self.haml[len(CONDITIONAL_COMMENT) + len(conditional) - 1:]
             self.before = "<!--%s>%s" % (conditional, content)
-            
+
         self.after = "<![endif]-->\n"
         self._render_children()
 
@@ -368,7 +376,10 @@ class DoctypeNode(HamlNode):
         parts = doctype.split()
         if parts and parts[0] == "XML":
             encoding = parts[1] if len(parts) > 1 else 'utf-8'
-            self.before = "<?xml version='1.0' encoding='%s' ?>" % encoding
+            self.before = "<?xml version=%s1.0%s encoding=%s%s%s ?>" % (
+                self.attr_wrapper, self.attr_wrapper,
+                self.attr_wrapper, encoding, self.attr_wrapper,
+            )
         else:
             types = {
                 "": '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
@@ -394,7 +405,7 @@ class VariableNode(ElementNode):
     def __init__(self, haml):
         ElementNode.__init__(self, haml)
         self.django_variable = True
-    
+
     def _render(self):
         tag_content = self.haml.lstrip(VARIABLE)
         self.before = "%s%s" % (self.spaces, self._render_inline_content(tag_content))
@@ -425,15 +436,15 @@ class TagNode(HamlNode):
                    'ifnotequal':'else',
                    'for':'empty',
                    'with':'with'}
-    
+
     def __init__(self, haml):
         HamlNode.__init__(self, haml)
         self.tag_statement = self.haml.lstrip(TAG).strip()
         self.tag_name = self.tag_statement.split(' ')[0]
-        
+
         if (self.tag_name in self.self_closing.values()):
             raise TypeError("Do not close your Django tags manually.  It will be done for you.")
-    
+
     def _render(self):
         self.before = "%s{%% %s %%}" % (self.spaces, self.tag_statement)
         if (self.tag_name in self.self_closing.keys()):
@@ -445,7 +456,7 @@ class TagNode(HamlNode):
             else:
                 self.after = self.render_newlines()
         self._render_children()
-    
+
     def should_contain(self, node):
         return isinstance(node, TagNode) and node.tag_name in self.may_contain.get(self.tag_name, '')
 
@@ -472,13 +483,13 @@ class FilterNode(HamlNode):
     def _post_render(self):
         # Don't post-render children of filter nodes as we don't want them to be interpreted as HAML
         pass
-      
+
 
 class PlainFilterNode(FilterNode):
     def __init__(self, haml):
         FilterNode.__init__(self, haml)
         self.empty_node = True
-    
+
     def _render(self):
         if self.children:
             first_indentation = self.children[0].indentation

--- a/hamlpy/template/loaders.py
+++ b/hamlpy/template/loaders.py
@@ -7,6 +7,13 @@ from hamlpy import hamlpy
 from hamlpy.template.utils import get_django_template_loaders
 
 
+# Get options from Django settings
+options_dict = {}
+from django.conf import settings
+if hasattr(settings, 'HAMLPY_ATTR_WRAPPER'):
+    options_dict.update(attr_wrapper=settings.HAMLPY_ATTR_WRAPPER)
+
+
 def get_haml_loader(loader):
     if hasattr(loader, 'Loader'):
         baseclass = loader.Loader
@@ -27,7 +34,7 @@ def get_haml_loader(loader):
                 except TemplateDoesNotExist:
                     pass
                 else:
-                    hamlParser = hamlpy.Compiler()
+                    hamlParser = hamlpy.Compiler(options_dict=options_dict)
                     html = hamlParser.process(haml_source)
 
                     return html, template_path

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -4,7 +4,7 @@ from nose.tools import eq_, raises
 from hamlpy import hamlpy
 
 class HamlPyTest(unittest.TestCase):
-        
+
     def test_applies_id_properly(self):
         haml = '%div#someId Some text'
         html = "<div id='someId'>Some text</div>"
@@ -18,7 +18,7 @@ class HamlPyTest(unittest.TestCase):
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))
-        
+
     def test_applies_multiple_classes_properly(self):
         haml = '%div.someClass.anotherClass Some text'
         html = "<div class='someClass anotherClass'>Some text</div>"
@@ -35,22 +35,22 @@ class HamlPyTest(unittest.TestCase):
         self.assertTrue("xml:lang='en'" in result)
         self.assertTrue("lang='en'" in result)
         self.assertTrue(result.endswith("></html>") or result.endswith("></html>\n"))
-    
+
     def test_dictionaries_support_arrays_for_id(self):
         haml = "%div{'id':('itemType', '5')}"
         html = "<div id='itemType_5'></div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))
-        
+
     def test_dictionaries_can_by_pythonic(self):
         haml = "%div{'id':['Article','1'], 'class':['article','entry','visible']} Booyaka"
         html = "<div id='Article_1' class='article entry visible'>Booyaka</div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))
-        
-          
+
+
     def test_html_comments_rendered_properly(self):
         haml = '/ some comment'
         html = "<!-- some comment -->"
@@ -60,17 +60,17 @@ class HamlPyTest(unittest.TestCase):
 
     def test_conditional_comments_rendered_properly(self):
         haml = "/[if IE]\n  %h1 You use a shitty browser"
-        html = "<!--[if IE]>\n  <h1>You use a shitty browser</h1>\n<![endif]-->"
+        html = "<!--[if IE]>\n  <h1>You use a shitty browser</h1>\n<![endif]-->\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_single_line_conditional_comments_rendered_properly(self):
         haml = "/[if IE] You use a shitty browser"
-        html = "<!--[if IE]> You use a shitty browser<![endif]-->"
+        html = "<!--[if IE]> You use a shitty browser<![endif]-->\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
-        eq_(html, result)        
+        eq_(html, result)
 
     def test_django_variables_on_tag_render_properly(self):
         haml = '%div= story.tease'
@@ -78,48 +78,48 @@ class HamlPyTest(unittest.TestCase):
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result.replace('\n', ''))
-    
+
     def test_stand_alone_django_variables_render(self):
         haml = '= story.tease'
         html = '{{ story.tease }}'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result.replace('\n', ''))
-    
+
     def test_stand_alone_django_tags_render(self):
         haml = '- extends "something.html"'
         html = '{% extends "something.html" %}'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result.replace('\n', ''))
-        
+
     def test_if_else_django_tags_render(self):
         haml = '- if something\n   %p hello\n- else\n   %p goodbye'
         html = '{% if something %}\n   <p>hello</p>\n{% else %}\n   <p>goodbye</p>\n{% endif %}\n'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
-    @raises(TypeError)   
+
+    @raises(TypeError)
     def test_throws_exception_when_trying_to_close_django(self):
         haml = '- endfor'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
-    
+
     def test_handles_dash_in_class_name_properly(self):
         haml = '.header.span-24.last'
         html = "<div class='header span-24 last'></div>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_handles_multiple_attributes_in_dict(self):
         haml = "%div{'id': ('article', '3'), 'class': ('newest', 'urgent')} Content"
         html = "<div id='article_3' class='newest urgent'>Content</div>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_inline_variables_are_parsed_correctly(self):
         haml = "={greeting} #{name}, how are you ={date}?"
         html = "{{ greeting }} {{ name }}, how are you {{ date }}?\n"
@@ -168,84 +168,84 @@ class HamlPyTest(unittest.TestCase):
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_inline_variables_escaping_works_at_start_of_line(self):
         haml = "\\={name}, how are you?"
         html = "={name}, how are you?\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_inline_variables_with_hash_escaping_works_at_start_of_line(self):
         haml = "\\#{name}, how are you?"
         html = "#{name}, how are you?\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_inline_variables_work_at_start_of_line(self):
         haml = "={name}, how are you?"
         html = "{{ name }}, how are you?\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_inline_variables_with_hash_work_at_start_of_line(self):
         haml = "#{name}, how are you?"
         html = "{{ name }}, how are you?\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_inline_variables_with_special_characters_are_parsed_correctly(self):
         haml = "%h1 Hello, #{person.name}, how are you?"
         html = "<h1>Hello, {{ person.name }}, how are you?</h1>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_plain_text(self):
         haml = "This should be plain text\n    This should be indented"
         html = "This should be plain text\n    This should be indented\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
-        eq_(html, result)   
-             
+        eq_(html, result)
+
     def test_plain_text_with_indenting(self):
         haml = "This should be plain text"
         html = "This should be plain text\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_escaped_haml(self):
         haml = "\\= Escaped"
         html = "= Escaped\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_utf8_with_regular_text(self):
         haml = u"%a{'href':'', 'title':'링크(Korean)'} Some Link"
         html = u"<a href='' title='\ub9c1\ud06c(Korean)'>Some Link</a>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-    
+
     def test_python_filter(self):
         haml = ":python\n   for i in range(0, 5): print \"<p>item \%s</p>\" % i"
         html = '<p>item \\0</p>\n<p>item \\1</p>\n<p>item \\2</p>\n<p>item \\3</p>\n<p>item \\4</p>\n'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_doctype_html5(self):
         haml = '!!! 5'
         html = '<!DOCTYPE html>'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result.replace('\n', ''))
-        
+
     def test_doctype_xhtml(self):
         haml = '!!!'
         html = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
@@ -272,7 +272,7 @@ class HamlPyTest(unittest.TestCase):
         html = "-This should be plain text\n.This should be more\n  This should be indented\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
-        eq_(html, result)   
+        eq_(html, result)
 
     def test_plain_filter_with_no_children(self):
         haml = ":plain\nNothing"
@@ -294,7 +294,7 @@ class HamlPyTest(unittest.TestCase):
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
     def test_pygments_filter(self):
         haml = '''
             :highlight
@@ -311,10 +311,28 @@ class HamlPyTest(unittest.TestCase):
                 + '\n<span class="k">else</span><span class="p">:</span>' \
                 + '\n    <span class="n">print</span> &quot;<span class="n">z</span>&quot;<span class="p">:</span>' \
                 + '\n</pre></div>\n'
-    
+
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
-        
+
+    def test_attr_wrapper(self):
+        haml = """
+%html{'xmlns':'http://www.w3.org/1999/xhtml', 'xml:lang':'en', 'lang':'en'}
+  %body#main
+    %div.wrap
+      %a{:href => '/'}"""
+        hamlParser = hamlpy.Compiler(options_dict={'attr_wrapper': '"'})
+        result = hamlParser.process(haml)
+        self.assertEqual(result,
+                         '''<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <body id="main">
+    <div class="wrap">
+      <a href="/"></a>
+    </div>
+  </body>
+</html>
+''')
+
 if __name__ == '__main__':
     unittest.main()

--- a/hamlpy/test/regression.py
+++ b/hamlpy/test/regression.py
@@ -26,7 +26,7 @@ class RegressionTest(unittest.TestCase):
     
     def test_for_newline_after_conditional_comment(self):
         haml = '/[if lte IE 7]\n\ttest\n#test'
-        haml = '<!--[if lte IE 7]>\n\ttest\n<![endif]-->\n<div id="test"></div>'
+        html = "<!--[if lte IE 7]>\n\ttest\n<![endif]-->\n<div id='test'></div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result.strip())

--- a/readme.md
+++ b/readme.md
@@ -86,25 +86,36 @@ For caching, just add `django.template.loaders.cached.Loader` to your TEMPLATE_L
 	    )),   
 	)
 
+#### Settings
+
+Following values in Django settings affect haml processing:
+
+  * `HAMLPY_ATTR_WRAPPER` -- The character that should wrap element attributes. This defaults to ' (an apostrophe).
+
 ### Option 2: Watcher 
 
 HamlPy can also be used as a stand-alone program. There is a script which will watch for changed hamlpy extensions and regenerate the html as they are edited:
 
-	hamlpy-watcher [-h] [-v] [-i EXT [EXT ...]] [-ext EXT] [-r S] input_dir [output_dir]
 
-	positional arguments:
-	  input_dir             Folder to watch
-	  output_dir            Destination folder
-	
-	optional arguments:
-	  -h, --help            show this help message and exit
-	  -v, --verbose         Display verbose output
-	  -i EXT [EXT ...], --input-extension EXT [EXT ...]
-	                        The file extensions to look for
-	  -ext EXT, --extension EXT
-	                        The output file extension. Default is .html
-	  -r S, --refresh S     Refresh interval for files. Default is 3 seconds
+        usage: hamlpy-watcher [-h] [-v] [-i EXT [EXT ...]] [-ext EXT] [-r S]
+                            [--tag TAG] [--attr-wrapper {",'}]
+                            input_dir [output_dir]
 
+        positional arguments:
+        input_dir             Folder to watch
+        output_dir            Destination folder
+
+        optional arguments:
+        -h, --help            show this help message and exit
+        -v, --verbose         Display verbose output
+        -i EXT [EXT ...], --input-extension EXT [EXT ...]
+                                The file extensions to look for
+        -ext EXT, --extension EXT
+                                The output file extension. Default is .html
+        -r S, --refresh S     Refresh interval for files. Default is 3 seconds
+        --tag TAG             Add self closing tag. eg. --tag macro:endmacro
+        --attr-wrapper {",'}  The character that should wrap element attributes.
+                                This defaults to ' (an apostrophe).
 
 Or to simply convert a file and output the result to your console:
 

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,10 @@ Or you can have it dump to a file:
 
 	hamlpy inputFile.haml outputFile.html
 
+Optionally, `--attr-wrapper` can be specified:
+
+    hamlpy inputFile.haml --attr-wrapper='"'
+
 For HamlPy developers, the `-d` switch can be used with `hamlpy` to debug the internal tree structure.
 	
 ## Reference


### PR DESCRIPTION
Hi, Jesse!

Thanks for such a great tool!

Please, review this pull request - it's about specifying attribute wrapper for generated html:

```
<a href='/'>
```

vs

```
<a href="/">
```

I think, other options can be specified the same way (on demand, if somebody needs them). For more, see: http://haml.info/docs/yardoc/Haml/Options.html

P.s. sorry for so many whitespace changes - it's done by my IDE.

David
