### PR TITLE
added compact notation for dynamic attributes

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -115,20 +115,23 @@ class Element(object):
             from codegen import to_source
             node = ast.parse(attribute_dict_string, mode='eval')
             s = []
-            for k,v in zip(node.body.keys, node.body.values):
+            for k, v in zip(node.body.keys, node.body.values):
                 if isinstance(k, ast.Name):
                     #k = '"{{ %s }}"' % k.id # TODO: allow dynamic keys in settings
                     k = '"%s"' % k.id
                 else:
                     k = to_source(k)
-                if isinstance(v, ast.Str): # TODO: add allowed types
+                if isinstance(v, ast.Str):  # TODO: add allowed types
                     v = to_source(v)
                 else:
                     v = '"{{ %s }}"' % to_source(v)
-                s.append('%s: %s' % (k,v))
+                s.append('%s: %s' % (k, v))
             attribute_dict_string = '{%s}' % ', '.join(s)
         except Exception as e:
-            pass
+            import traceback
+            traceback.print_exc()
+            print repr(e)
+            attribute_dict_string = 'error: "%s"' % repr(e).replace('"', "'")
         return attribute_dict_string
 
     def _parse_attribute_dictionary(self, attribute_dict_string):
@@ -167,8 +170,7 @@ class Element(object):
                             self.attributes += "%s=%s " % (k, self.attr_wrap(v))
                 self.attributes = self.attributes.strip()
             except Exception, e:
-                raise Exception('failed to decode: %s' % attribute_dict_string)
-                #raise Exception('failed to decode: %s. Details: %s'%(attribute_dict_string, e))
+                raise Exception('failed to decode: %s. Error: %r' % (attribute_dict_string, e))
 
         return attributes_dict
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='hamlpy',
       url = 'http://github.com/jessemiller/HamlPy',
       license = 'MIT',
       install_requires = [
+          'codegen',
           'django',
           'pygments',
           'markdown'


### PR DESCRIPTION
In case you are using Jinja2 with HamlPy, you may be interested in more compact expressions for dynamic attributes, for example

``` haml
- extends 'campaign/base.html'

- block main_content
  %h1 Campaigns
  %ol
    - for campaign in campaigns
      %li{class: "campaign"}
        %a{style: "color:red", href: url_to(campaign), style:'color:green'}= campaign.title
        %a{href: url_to(campaign)} Show
        %a{href: url_to(campaign, "edit")} Edit
        %a{href: url_to(campaign, "delete")} Delete

  .well
    %a{href: url('campaign.new')} New
```

The proposed commit allows successful compiling of such code, however, it is currently posted more for the sake of discussion than pulling to master. Please, let me know what you think.

P.S. It needs an extra requirement, the well-known codegen by Armin from 2008, which I have just submitted to pypi to simplify its usage (it is under BSD). I don't intend to change it in the future, since the original code seems working perfectly for our case. There is a new package called astor which also provides codegen, but I was not confident in it.
