### PR TITLE
Fix #114 HamlPyExtension filename extension check invalid

### DIFF
--- a/hamlpy/ext.py
+++ b/hamlpy/ext.py
@@ -21,8 +21,7 @@ def get_file_extension(file_path):
 
 def has_any_extension(file_path, extensions):
     file_ext = get_file_extension(file_path)
-    return file_ext and extensions and [clean_extension(e) for e in extensions]
-
+    return file_ext and extensions and file_ext in [clean_extension(e) for e in extensions]
 
 class HamlPyExtension(jinja2.ext.Extension):
 

--- a/hamlpy/test/ext_test.py
+++ b/hamlpy/test/ext_test.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+from hamlpy.ext import has_any_extension
+
+class ExtTest(unittest.TestCase):
+    """
+    Tests for methods found in ../ext.py
+    """
+    
+    def test_has_any_extension(self):
+        extensions = [
+            'hamlpy',
+            'haml',
+            '.txt'
+        ]
+        # no directory
+        self.assertTrue(has_any_extension('dir.hamlpy', extensions))
+        self.assertTrue(has_any_extension('dir.haml', extensions))
+        self.assertTrue(has_any_extension('dir.txt', extensions))
+        self.assertFalse(has_any_extension('dir.html', extensions))
+        # with dot in filename
+        self.assertTrue(has_any_extension('dir.dot.hamlpy', extensions))
+        self.assertTrue(has_any_extension('dir.dot.haml', extensions))
+        self.assertTrue(has_any_extension('dir.dot.txt', extensions))
+        self.assertFalse(has_any_extension('dir.dot.html', extensions))
+        
+        # relative path
+        self.assertTrue(has_any_extension('../dir.hamlpy', extensions))
+        self.assertTrue(has_any_extension('../dir.haml', extensions))
+        self.assertTrue(has_any_extension('../dir.txt', extensions))
+        self.assertFalse(has_any_extension('../dir.html', extensions))
+        # with dot in filename
+        self.assertTrue(has_any_extension('../dir.dot.hamlpy', extensions))
+        self.assertTrue(has_any_extension('../dir.dot.haml', extensions))
+        self.assertTrue(has_any_extension('../dir.dot.txt', extensions))
+        self.assertFalse(has_any_extension('../dir.dot.html', extensions))
+        
+        # absolute paths
+        self.assertTrue(has_any_extension('/home/user/dir.hamlpy', extensions))
+        self.assertTrue(has_any_extension('/home/user/dir.haml', extensions))
+        self.assertTrue(has_any_extension('/home/user/dir.txt', extensions))
+        self.assertFalse(has_any_extension('/home/user/dir.html', extensions))
+        # with dot in filename
+        self.assertTrue(has_any_extension('/home/user/dir.dot.hamlpy', extensions))
+        self.assertTrue(has_any_extension('/home/user/dir.dot.haml', extensions))
+        self.assertTrue(has_any_extension('/home/user/dir.dot.txt', extensions))
+        self.assertFalse(has_any_extension('/home/user/dir.dot.html', extensions))


### PR DESCRIPTION
Fix  to issue #114 using @aydinyanik's proposed fix.
