### PR TITLE
Django translations, Issue #96, and small fix

### DIFF
--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -10,9 +10,9 @@ import hamlpy
 def decorate_templatize(func):
 	def templatize(src, origin=None):
 		hamlParser = hamlpy.Compiler()
-		html = hamlParser.process(src)
-		return func(html, origin)
-	
+		html = hamlParser.process(src.decode('utf-8'))
+		return func(html.encode('utf-8'), origin)
+
 	return templatize
 
 trans_real.templatize = decorate_templatize(trans_real.templatize)

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,16 @@ Optionally, `--attr-wrapper` can be specified:
 
 For HamlPy developers, the `-d` switch can be used with `hamlpy` to debug the internal tree structure.
 	
+### Create message files for translation
+
+There is a very simple solution.
+
+	django-admin.py makemessages --settings=<project.settings> -a
+	
+Where:
+
+  * <project.settings> -- Django configuration file where  module "hamlpy" is configured properly.
+	
 ## Reference
 
 Check out the [reference.md](http://github.com/jessemiller/HamlPy/blob/master/reference.md "HamlPy Reference") file for a complete reference and more examples.

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ There is a very simple solution.
 	
 Where:
 
-  * <project.settings> -- Django configuration file where  module "hamlpy" is configured properly.
+  * project.settings -- Django configuration file where  module "hamlpy" is configured properly.
 	
 ## Reference
 


### PR DESCRIPTION
I added to the documentation instructions on how to start creating translation files.

I also added to convert the input string to Unicode (hamlParser.process, hamlpy/templatize.py).

Because occur some errors when converting templates with Unicode characters.

Now it is standardized, and like in "hamlpy/hamlpy/template/loaders.py" line 38 "hamlParser.process (haml_source)", the string is a unicode type.
