### PR TITLE
make the test of non-ascii filenames actually pass, by marking strings as unicode

### DIFF
--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -13,8 +13,8 @@ class HamlPyTest(unittest.TestCase):
         self.assertEqual(html, result.replace('\n', ''))
 
     def test_non_ascii_id_allowed(self):
-        haml = '%div#これはテストです test'
-        html = "<div id='これはテストです'>test</div>"
+        haml = u'%div#これはテストです test'
+        html = u"<div id='これはテストです'>test</div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))


### PR DESCRIPTION
I missed the note about how to run the unit tests when submitting this patch, and it turns out the test actually failed. Just needed to mark the appropriate strings as unicode to get it to work.
