### PR TITLE
Fix Markdown br bug

### DIFF
--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -593,10 +593,14 @@ class MarkdownFilterNode(FilterNode):
         if self.children:
             if not _markdown_available:
                 raise NotAvailableError("Markdown is not available")
-
             self.before = self.render_newlines()[1:]
             indent_offset = len(self.children[0].spaces)
-            text = ''.join(''.join([c.spaces[indent_offset:], c.raw_haml.lstrip(), c.render_newlines()]) for c in self.children)
-            self.before += markdown(text)
+            lines = []
+            for c in self.children:
+                haml = c.raw_haml.lstrip()
+                if haml[-1] == '\n':
+                    haml = haml[:-1]
+                lines.append(c.spaces[indent_offset:] + haml + c.render_newlines())
+            self.before += markdown( ''.join(lines))
         else:
             self.after = self.render_newlines()

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -596,7 +596,7 @@ class MarkdownFilterNode(FilterNode):
 
             self.before = self.render_newlines()[1:]
             indent_offset = len(self.children[0].spaces)
-            text = ''.join(''.join([c.spaces[indent_offset:], c.haml, c.render_newlines()]) for c in self.children)
+            text = ''.join(''.join([c.spaces[indent_offset:], c.raw_haml.lstrip(), c.render_newlines()]) for c in self.children)
             self.before += markdown(text)
         else:
             self.after = self.render_newlines()

--- a/hamlpy/test/templates/filtersMarkdown.hamlpy
+++ b/hamlpy/test/templates/filtersMarkdown.hamlpy
@@ -2,6 +2,9 @@
   hello
   no paragraph
 
+  line break  
+  follow
+
   New paragraph
 
-      test
+      code block

--- a/hamlpy/test/templates/filtersMarkdown.html
+++ b/hamlpy/test/templates/filtersMarkdown.html
@@ -1,5 +1,7 @@
 <p>hello
 no paragraph</p>
+<p>line break<br />
+follow</p>
 <p>New paragraph</p>
-<pre><code>test
+<pre><code>code block
 </code></pre>


### PR DESCRIPTION
In the `:markdown` filter, the markdown for implicit `<br>` tag is broken.

The reason is that markdown recognises a line with  `<br>` by two trailing spaces.

However, trailing spaces are stripped when `PlaintextNode.haml` is read.

To fix: when the text is reconstructed to send to the Markdown filter, instead of using the `PlaintextNode.haml` field, `PlaintextNode.raw_haml.lstrip()` is used, which keeps the trailing spaces.
