### PR TITLE
Fix to templatize decorator so it only hamlpy parses files with valid haml extensions see Issue #96

### DIFF
--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -1,20 +1,20 @@
 """
 This module decorates the django templatize function to parse haml templates
 before the translation utility extracts tags from it.
- 
+
 --Modified to ignore non-haml files.
 """
- 
+
 try:
     from django.utils.translation import trans_real
     _django_available = True
 except ImportError, e:
     _django_available = False
- 
+
 import hamlpy
 import os
- 
- 
+
+
 def decorate_templatize(func):
     def templatize(src, origin=None):
         #if the template has no origin file then do not attempt to parse it with haml
@@ -26,6 +26,6 @@ def decorate_templatize(func):
                 src = html.encode('utf-8')
         return func(src, origin)
     return templatize
- 
+
 if _django_available:
     trans_real.templatize = decorate_templatize(trans_real.templatize)

--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -1,25 +1,31 @@
 """
 This module decorates the django templatize function to parse haml templates
 before the translation utility extracts tags from it.
+ 
+--Modified to ignore non-haml files.
 """
-
+ 
 try:
     from django.utils.translation import trans_real
     _django_available = True
 except ImportError, e:
     _django_available = False
-
+ 
 import hamlpy
-
-
+import os
+ 
+ 
 def decorate_templatize(func):
-	def templatize(src, origin=None):
-		hamlParser = hamlpy.Compiler()
-		html = hamlParser.process(src.decode('utf-8'))
-		return func(html.encode('utf-8'), origin)
-
-	return templatize
-
+    def templatize(src, origin=None):
+        #if the template has no origin file then do not attempt to parse it with haml
+        if origin:
+            #if the template has a source file, then only parse it if it is haml
+            if os.path.splitext(origin)[1].lower() in ['.'+x.lower() for x in hamlpy.VALID_EXTENSIONS]:
+                hamlParser = hamlpy.Compiler()
+                html = hamlParser.process(src.decode('utf-8'))
+                src = html.encode('utf-8')
+        return func(src, origin)
+    return templatize
+ 
 if _django_available:
     trans_real.templatize = decorate_templatize(trans_real.templatize)
-


### PR DESCRIPTION
As mentioned in Issue #96 without this patch templatize may choke on non haml files causing issues with makemessages.
