### PR TITLE
Add call and macro tags to the self-closing dict

### DIFF
--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -440,6 +440,8 @@ class TagNode(HamlNode):
                     'comment': 'endcomment',
                     'cache': 'endcache',
                     'localize': 'endlocalize',
+                    'call': 'endcall',
+                    'macro': 'endmacro',
                     'compress': 'endcompress'}
     may_contain = {'if':['else', 'elif'],
                    'ifchanged':'else',


### PR DESCRIPTION
Jinja2 has macro/endmacro and call/endcall tags
