### PR TITLE
{% include %} template tags do not work with non-VALID_EXTENSIONS

### DIFF
--- a/hamlpy/hamlpy.py
+++ b/hamlpy/hamlpy.py
@@ -4,6 +4,13 @@ from optparse import OptionParser
 import sys
 
 VALID_EXTENSIONS=['haml', 'hamlpy']
+try:
+    from django.conf import settings
+except ImportError, e:
+    pass
+else:
+    if hasattr(settings, 'HAMLPY_VALID_EXTENSIONS'):
+        VALID_EXTENSIONS.extend(settings.HAMLPY_VALID_EXTENSIONS)
 
 class Compiler:
 

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ For caching, just add `django.template.loaders.cached.Loader` to your TEMPLATE_L
 Following values in Django settings affect haml processing:
 
   * `HAMLPY_ATTR_WRAPPER` -- The character that should wrap element attributes. This defaults to ' (an apostrophe).
+  * `HAMLPY_VALID_EXTENSIONS` -- A list of additional file extensions that are loaded/watched by HamlPy. By default, HamlPy monitors files with `.haml` and `.hamlpy` extensions.
 
 ### Option 2: Watcher 
 


### PR DESCRIPTION
I tend to embed inline javascript snippets by using [`{% include %}` django template tags](https://docs.djangoproject.com/en/dev/ref/templates/builtins/?from=olddocs#include) like this:

```
-# template.haml
!!! 5
%html
    %body
        %p hello world
        %script
            {% autoescape off %}
            {% include "path/to/file.js" %}
            {% endautoescape %}
```

This is convenient because my editor can then use the appropriate javascript syntax highlighting rather than the haml syntax highlighting. The problem is that this produces a `RuntimeError` (maximum recursion dept exceeded while calling a Python object) for any templates that are `{% include %}`-ed but do not end in one of the `hamlpy.VALID_EXTENSIONS`. Bummer.

I might recommend making `VALID_EXTENSIONS` a settings variable within the hamlpy app that can easily be extended in the site settings.py. 
