### PR TITLE
makemessages needs to be telled to parse .haml files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,7 @@ For HamlPy developers, the `-d` switch can be used with `hamlpy` to debug the in
 
 There is a very simple solution.
 
-	django-admin.py makemessages --settings=<project.settings> -a
+	django-admin.py makemessages --settings=<project.settings> -a --extension haml,html,py,txt
 	
 Where:
 


### PR DESCRIPTION
Hello,

I add to explicitly ask makemessages to parse .haml files in django 1.8 (untested on other versions). This should avoid other people to stupidly lose hours like me.

Kind regards,
