### PR TITLE
Add Python 3 support [Works, but failing tests]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hamlpy.egg-info
 .project
 .pydevproject
 .DS_Store
+*egg-info/*

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+#
+# deploy.sh
+# Copyright (C) 2015 dhilipsiva <dhilipsiva@gmail.com>
+#
+# Distributed under terms of the MIT license.
+#
+
+rm -rf dist/
+python setup.py sdist
+python setup.py bdist_wheel
+twine upload dist/*

--- a/hamlpy/__init__.py
+++ b/hamlpy/__init__.py
@@ -1,1 +1,1 @@
-import templatize
+from . import templatize

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -122,7 +122,7 @@ class Element(object):
                 attribute_dict_string = re.sub(self.ATTRIBUTE_REGEX, '\g<pre>"\g<key>":\g<val>', attribute_dict_string)
                 # Parse string as dictionary
                 attributes_dict = eval(attribute_dict_string)
-                for k, v in attributes_dict.items():
+                for k, v in list(attributes_dict.items()):
                     if k != 'id' and k != 'class':
                         if isinstance(v, NoneType):
                             self.attributes += "%s " % (k,)
@@ -140,7 +140,7 @@ class Element(object):
                             v = v.decode('utf-8')
                             self.attributes += "%s=%s " % (k, self.attr_wrap(self._escape_attribute_quotes(v)))
                 self.attributes = self.attributes.strip()
-            except Exception, e:
+            except Exception as e:
                 raise Exception('failed to decode: %s' % attribute_dict_string)
                 #raise Exception('failed to decode: %s. Details: %s'%(attribute_dict_string, e))
 

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from types import NoneType
 
 class Element(object):
     """contains the pieces of an element and can populate itself from haml element text"""
@@ -124,7 +123,7 @@ class Element(object):
                 attributes_dict = eval(attribute_dict_string)
                 for k, v in list(attributes_dict.items()):
                     if k != 'id' and k != 'class':
-                        if isinstance(v, NoneType):
+                        if v is None:
                             self.attributes += "%s " % (k,)
                         elif isinstance(v, int) or isinstance(v, float):
                             self.attributes += "%s=%s " % (k, self.attr_wrap(v))
@@ -137,7 +136,11 @@ class Element(object):
                                                  "\nPlease use inline variables ={...} instead.\n-------------------\n")
 
                             attributes_dict[k] = v
-                            v = v.decode('utf-8')
+                            try:
+                                v = v.decode('utf-8')
+                            except Exception:
+                                # Everyting is unicde in python 3
+                                pass
                             self.attributes += "%s=%s " % (k, self.attr_wrap(self._escape_attribute_quotes(v)))
                 self.attributes = self.attributes.strip()
             except Exception as e:
@@ -145,7 +148,3 @@ class Element(object):
                 #raise Exception('failed to decode: %s. Details: %s'%(attribute_dict_string, e))
 
         return attributes_dict
-
-
-
-

--- a/hamlpy/ext.py
+++ b/hamlpy/ext.py
@@ -2,17 +2,17 @@
 try:
     import jinja2.ext
     _jinja2_available = True
-except ImportError, e:
+except ImportError as e:
     _jinja2_available = False
 
-import hamlpy
+from . import hamlpy
 import os
 
 HAML_FILE_NAME_EXTENSIONS = ['haml', 'hamlpy']
 
 
 def clean_extension(file_ext):
-    if not isinstance(file_ext, basestring):
+    if not isinstance(file_ext, str):
         raise Exception('Wrong file extension format: %r' % file_ext)
     if len(file_ext) > 1 and file_ext.startswith('.'):
         file_ext = file_ext[1:]

--- a/hamlpy/hamlpy.py
+++ b/hamlpy/hamlpy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from nodes import RootNode, FilterNode, HamlNode, create_node
+from .nodes import RootNode, FilterNode, HamlNode, create_node
 from optparse import OptionParser
 import sys
 
@@ -30,7 +30,7 @@ class Compiler:
 
                     while line.count('{') - line.count('}') != -1:
                         try:
-                            line = line_iter.next()
+                            line = next(line_iter)
                         except StopIteration:
                             raise Exception('No closing brace found for multi-line HAML beginning at line %s' % (start_multiline+1))
                         node_lines += line
@@ -66,7 +66,7 @@ def convert_files():
     (options, args) = parser.parse_args()
 
     if len(args) < 1:
-        print "Specify the input file as the first argument."
+        print("Specify the input file as the first argument.")
     else:
         infile = args[0]
         haml_lines = codecs.open(infile, 'r', encoding='utf-8').read().splitlines()
@@ -78,7 +78,7 @@ def convert_files():
             outfile = codecs.open(args[1], 'w', encoding='utf-8')
             outfile.write(output)
         else:
-            print output
+            print(output)
 
 if __name__ == '__main__':
     convert_files()

--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -70,7 +70,7 @@ def watch_folder():
     
     if args.verbose:
         Options.VERBOSE = True
-        print("Watching {} at refresh interval {} seconds".format(input_folder, args.refresh))
+        print(("Watching {} at refresh interval {} seconds".format(input_folder, args.refresh)))
     
     if args.extension:
         Options.OUTPUT_EXT = args.extension
@@ -136,10 +136,10 @@ def _compiled_path(destination, filename):
 def compile_file(fullpath, outfile_name, compiler_args):
     """Calls HamlPy compiler."""
     if Options.VERBOSE:
-        print('%s %s -> %s' % (strftime("%H:%M:%S"), fullpath, outfile_name))
+        print(('%s %s -> %s' % (strftime("%H:%M:%S"), fullpath, outfile_name)))
     try:
         if Options.DEBUG:
-            print("Compiling %s -> %s" % (fullpath, outfile_name))
+            print(("Compiling %s -> %s" % (fullpath, outfile_name)))
         haml_lines = codecs.open(fullpath, 'r', encoding = 'utf-8').read().splitlines()
         compiler = hamlpy.Compiler(compiler_args)
         output = compiler.process_lines(haml_lines)
@@ -147,7 +147,7 @@ def compile_file(fullpath, outfile_name, compiler_args):
         outfile.write(output)
     except Exception as e:
         # import traceback
-        print("Failed to compile %s -> %s\nReason:\n%s" % (fullpath, outfile_name, e))
+        print(("Failed to compile %s -> %s\nReason:\n%s" % (fullpath, outfile_name, e)))
         # print traceback.print_exc()
 
 if __name__ == '__main__':

--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -10,11 +10,11 @@ import codecs
 import os
 import os.path
 import time
-import hamlpy
-import nodes as hamlpynodes
+from . import hamlpy
+from . import nodes as hamlpynodes
 
 try:
-    str = unicode
+    str = str
 except NameError:
     pass
 
@@ -70,7 +70,7 @@ def watch_folder():
     
     if args.verbose:
         Options.VERBOSE = True
-        print "Watching {} at refresh interval {} seconds".format(input_folder, args.refresh)
+        print("Watching {} at refresh interval {} seconds".format(input_folder, args.refresh))
     
     if args.extension:
         Options.OUTPUT_EXT = args.extension
@@ -136,18 +136,18 @@ def _compiled_path(destination, filename):
 def compile_file(fullpath, outfile_name, compiler_args):
     """Calls HamlPy compiler."""
     if Options.VERBOSE:
-        print '%s %s -> %s' % (strftime("%H:%M:%S"), fullpath, outfile_name)
+        print('%s %s -> %s' % (strftime("%H:%M:%S"), fullpath, outfile_name))
     try:
         if Options.DEBUG:
-            print "Compiling %s -> %s" % (fullpath, outfile_name)
+            print("Compiling %s -> %s" % (fullpath, outfile_name))
         haml_lines = codecs.open(fullpath, 'r', encoding = 'utf-8').read().splitlines()
         compiler = hamlpy.Compiler(compiler_args)
         output = compiler.process_lines(haml_lines)
         outfile = codecs.open(outfile_name, 'w', encoding = 'utf-8')
         outfile.write(output)
-    except Exception, e:
+    except Exception as e:
         # import traceback
-        print "Failed to compile %s -> %s\nReason:\n%s" % (fullpath, outfile_name, e)
+        print("Failed to compile %s -> %s\nReason:\n%s" % (fullpath, outfile_name, e))
         # print traceback.print_exc()
 
 if __name__ == '__main__':

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -1,21 +1,21 @@
 import re
 import sys
-from StringIO import StringIO
+from io import StringIO
 
-from elements import Element
+from .elements import Element
 
 try:
     from pygments import highlight
     from pygments.formatters import HtmlFormatter
     from pygments.lexers import guess_lexer
     _pygments_available = True
-except ImportError, e:
+except ImportError as e:
     _pygments_available = False
 
 try:
     from markdown import markdown
     _markdown_available = True
-except ImportError, e:
+except ImportError as e:
     _markdown_available = False
 
 class NotAvailableError(Exception):
@@ -453,12 +453,12 @@ class TagNode(HamlNode):
         self.tag_statement = self.haml.lstrip(TAG).strip()
         self.tag_name = self.tag_statement.split(' ')[0]
 
-        if (self.tag_name in self.self_closing.values()):
+        if (self.tag_name in list(self.self_closing.values())):
             raise TypeError("Do not close your Django tags manually.  It will be done for you.")
 
     def _render(self):
         self.before = "%s{%% %s %%}" % (self.spaces, self.tag_statement)
-        if (self.tag_name in self.self_closing.keys()):
+        if (self.tag_name in list(self.self_closing.keys())):
             self.before += self.render_newlines()
             self.after = '%s{%% %s %%}%s' % (self.spaces, self.self_closing[self.tag_name], self.render_newlines())
         else:
@@ -517,7 +517,7 @@ class PythonFilterNode(FilterNode):
             buffer = StringIO()
             sys.stdout = buffer
             try:
-                exec compiled_code
+                exec(compiled_code)
             except Exception as e:
                 # Change exception message to let developer know that exception comes from
                 # a PythonFilterNode

--- a/hamlpy/template/__init__.py
+++ b/hamlpy/template/__init__.py
@@ -1,3 +1,3 @@
-from loaders import haml_loaders as _loaders
+from .loaders import haml_loaders as _loaders
 
 locals().update(_loaders)

--- a/hamlpy/template/loaders.py
+++ b/hamlpy/template/loaders.py
@@ -4,7 +4,7 @@ try:
     from django.template import TemplateDoesNotExist
     from django.template.loaders import filesystem, app_directories
     _django_available = True
-except ImportError, e:
+except ImportError as e:
     class TemplateDoesNotExist(Exception):
         pass
 

--- a/hamlpy/template/utils.py
+++ b/hamlpy/template/utils.py
@@ -5,7 +5,7 @@ from os.path import dirname, splitext
 try:
   from django.template import loaders
   _django_available = True
-except ImportError, e:
+except ImportError as e:
   _django_available = False
 
 MODULE_EXTENSIONS = tuple([suffix[0] for suffix in imp.get_suffixes()])

--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -8,10 +8,10 @@ before the translation utility extracts tags from it.
 try:
     from django.utils.translation import trans_real
     _django_available = True
-except ImportError, e:
+except ImportError as e:
     _django_available = False
 
-import hamlpy
+from . import hamlpy
 import os
 
 

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -13,8 +13,8 @@ class HamlPyTest(unittest.TestCase):
         self.assertEqual(html, result.replace('\n', ''))
 
     def test_non_ascii_id_allowed(self):
-        haml = u'%div#これはテストです test'
-        html = u"<div id='これはテストです'>test</div>"
+        haml = '%div#これはテストです test'
+        html = "<div id='これはテストです'>test</div>"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         self.assertEqual(html, result.replace('\n', ''))
@@ -233,8 +233,8 @@ class HamlPyTest(unittest.TestCase):
         eq_(html, result)
 
     def test_utf8_with_regular_text(self):
-        haml = u"%a{'href':'', 'title':'링크(Korean)'} Some Link"
-        html = u"<a href='' title='\ub9c1\ud06c(Korean)'>Some Link</a>\n"
+        haml = "%a{'href':'', 'title':'링크(Korean)'} Some Link"
+        html = "<a href='' title='\ub9c1\ud06c(Korean)'>Some Link</a>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -234,13 +234,13 @@ class HamlPyTest(unittest.TestCase):
 
     def test_utf8_with_regular_text(self):
         haml = "%a{'href':'', 'title':'링크(Korean)'} Some Link"
-        html = "<a href='' title='\ub9c1\ud06c(Korean)'>Some Link</a>\n"
+        html = "<a href='' title='\\ub9c1\\ud06c(Korean)'>Some Link</a>\n"
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)
         eq_(html, result)
 
     def test_python_filter(self):
-        haml = ":python\n   for i in range(0, 5): print \"<p>item \%s</p>\" % i"
+        haml = ":python\n   for i in range(0, 5): print(\"<p>item \%s</p>\" % i)"
         html = '<p>item \\0</p>\n<p>item \\1</p>\n<p>item \\2</p>\n<p>item \\3</p>\n<p>item \\4</p>\n'
         hamlParser = hamlpy.Compiler()
         result = hamlParser.process(haml)

--- a/hamlpy/test/loader_test.py
+++ b/hamlpy/test/loader_test.py
@@ -5,7 +5,7 @@ try:
   from django.conf import settings
 
   settings.configure(DEBUG=True, TEMPLATE_DEBUG=True)
-except ImportError, e:
+except ImportError as e:
   pass
 
 from hamlpy.template.loaders import get_haml_loader, TemplateDoesNotExist

--- a/hamlpy/test/template_compare_test.py
+++ b/hamlpy/test/template_compare_test.py
@@ -84,18 +84,18 @@ class TestTemplateCompare(unittest.TestCase):
         
         for i, _ in enumerate(shorter):
             if len(shorter) <= i + 1:
-                print 'Ran out of characters to compare!'
-                print 'Actual len=%d' % len(s1)
-                print 'Expected len=%d' % len(s2)
+                print('Ran out of characters to compare!')
+                print('Actual len=%d' % len(s1))
+                print('Expected len=%d' % len(s2))
                 break
             if s1[i] != s2[i]:
-                print 'Difference begins at line', line, 'column', col
+                print('Difference begins at line', line, 'column', col)
                 actual_line = s1.splitlines()[line - 1]
                 expected_line = s2.splitlines()[line - 1]
-                print 'HTML (actual, len=%2d)   : %s' % (len(actual_line), actual_line)
-                print 'HTML (expected, len=%2d) : %s' % (len(expected_line), expected_line)
-                print 'Character code (actual)  : %d (%s)' % (ord(s1[i]), s1[i])
-                print 'Character code (expected): %d (%s)' % (ord(s2[i]), s2[i])
+                print('HTML (actual, len=%2d)   : %s' % (len(actual_line), actual_line))
+                print('HTML (expected, len=%2d) : %s' % (len(expected_line), expected_line))
+                print('Character code (actual)  : %d (%s)' % (ord(s1[i]), s1[i]))
+                print('Character code (expected): %d (%s)' % (ord(s2[i]), s2[i]))
                 break
 
             if shorter[i] == '\n':
@@ -104,7 +104,7 @@ class TestTemplateCompare(unittest.TestCase):
             else:
                 col += 1
         else:
-            print "No Difference Found"
+            print("No Difference Found")
 
     def _compare_test_files(self, name):
         haml_lines = codecs.open('templates/' + name + '.hamlpy', encoding = 'utf-8').readlines()
@@ -118,8 +118,8 @@ class TestTemplateCompare(unittest.TestCase):
         html = html.replace('\r', '')
         
         if parsed != html:
-            print '\nHTML (actual): '
-            print '\n'.join(["%d. %s" % (i + 1, l) for i, l in enumerate(parsed.split('\n')) ])
+            print('\nHTML (actual): ')
+            print('\n'.join(["%d. %s" % (i + 1, l) for i, l in enumerate(parsed.split('\n')) ]))
             self._print_diff(parsed, html)
         eq_(parsed, html)
         

--- a/hamlpy/test/template_compare_test.py
+++ b/hamlpy/test/template_compare_test.py
@@ -85,17 +85,17 @@ class TestTemplateCompare(unittest.TestCase):
         for i, _ in enumerate(shorter):
             if len(shorter) <= i + 1:
                 print('Ran out of characters to compare!')
-                print('Actual len=%d' % len(s1))
-                print('Expected len=%d' % len(s2))
+                print(('Actual len=%d' % len(s1)))
+                print(('Expected len=%d' % len(s2)))
                 break
             if s1[i] != s2[i]:
-                print('Difference begins at line', line, 'column', col)
+                print(('Difference begins at line', line, 'column', col))
                 actual_line = s1.splitlines()[line - 1]
                 expected_line = s2.splitlines()[line - 1]
-                print('HTML (actual, len=%2d)   : %s' % (len(actual_line), actual_line))
-                print('HTML (expected, len=%2d) : %s' % (len(expected_line), expected_line))
-                print('Character code (actual)  : %d (%s)' % (ord(s1[i]), s1[i]))
-                print('Character code (expected): %d (%s)' % (ord(s2[i]), s2[i]))
+                print(('HTML (actual, len=%2d)   : %s' % (len(actual_line), actual_line)))
+                print(('HTML (expected, len=%2d) : %s' % (len(expected_line), expected_line)))
+                print(('Character code (actual)  : %d (%s)' % (ord(s1[i]), s1[i])))
+                print(('Character code (expected): %d (%s)' % (ord(s2[i]), s2[i])))
                 break
 
             if shorter[i] == '\n':
@@ -119,7 +119,7 @@ class TestTemplateCompare(unittest.TestCase):
         
         if parsed != html:
             print('\nHTML (actual): ')
-            print('\n'.join(["%d. %s" % (i + 1, l) for i, l in enumerate(parsed.split('\n')) ]))
+            print(('\n'.join(["%d. %s" % (i + 1, l) for i, l in enumerate(parsed.split('\n')) ])))
             self._print_diff(parsed, html)
         eq_(parsed, html)
         

--- a/hamlpy/test/templates/filters.hamlpy
+++ b/hamlpy/test/templates/filters.hamlpy
@@ -15,4 +15,4 @@
 :python
   a=1
   for i in range(5):
-    print a+i
+    print(a+i)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # HamlPy
 
+A python 3 fork & drop-in replacement of HamlPy.
+
 HamlPy (pronounced "haml pie") is a tool for Django developers who want to use a Haml like syntax for their templates.
 HamlPy is not a template engine in itself but simply a compiler which will convert HamlPy files into templates that Django can understand.
 
@@ -10,17 +12,17 @@ But wait, what is Haml?  Haml is an incredible template engine written in Ruby u
 
 ### Stable release
 
-The latest stable version of HamlPy can be installed using [setuptools](http://pypi.python.org/pypi/setuptools/) `easy_install hamlpy` or  [pip](http://pypi.python.org/pypi/pip/) (`pip install hamlpy`)
+The latest stable version of HamlPy can be installed using [setuptools](http://pypi.python.org/pypi/setuptools/) `easy_install hamlpy` or  [pip](http://pypi.python.org/pypi/pip/) (`pip install hamlpy3`)
 
 ### Development
 
 The latest development version can be installed directly from GitHub:
 
-    pip install https://github.com/jessemiller/HamlPy/tarball/master
+    pip install https://github.com/appknox/HamlPy3/tarball/master
 
 ## Syntax
 
-Almost all of the XHTML syntax of Haml is preserved.  
+Almost all of the XHTML syntax of Haml is preserved.
 
 	#profile
 		.left.column
@@ -28,7 +30,7 @@ Almost all of the XHTML syntax of Haml is preserved.
 			#address Toronto, ON
 		.right.column
 			#bio Jesse Miller
-			
+
 turns into..
 
 	<div id='profile'>
@@ -40,7 +42,7 @@ turns into..
 			<div id='bio'>Jesse Miller</div>
 		</div>
 	</div>
-	
+
 
 The main difference is instead of interpreting Ruby, or even Python we instead can create Django Tags and Variables
 
@@ -66,7 +68,7 @@ Add the HamlPy template loaders to the Django template loaders:
 
     TEMPLATE_LOADERS = (
 	    'hamlpy.template.loaders.HamlPyFilesystemLoader',
-	    'hamlpy.template.loaders.HamlPyAppDirectoriesLoader',   
+	    'hamlpy.template.loaders.HamlPyAppDirectoriesLoader',
         ...
     )
 
@@ -83,7 +85,7 @@ For caching, just add `django.template.loaders.cached.Loader` to your TEMPLATE_L
 		    'hamlpy.template.loaders.HamlPyFilesystemLoader',
 		    'hamlpy.template.loaders.HamlPyAppDirectoriesLoader',
 		    ...
-	    )),   
+	    )),
 	)
 
 #### Settings
@@ -92,7 +94,7 @@ Following values in Django settings affect haml processing:
 
   * `HAMLPY_ATTR_WRAPPER` -- The character that should wrap element attributes. This defaults to ' (an apostrophe).
 
-### Option 2: Watcher 
+### Option 2: Watcher
 
 HamlPy can also be used as a stand-alone program. There is a script which will watch for changed hamlpy extensions and regenerate the html as they are edited:
 
@@ -121,7 +123,7 @@ HamlPy can also be used as a stand-alone program. There is a script which will w
 Or to simply convert a file and output the result to your console:
 
 	hamlpy inputFile.haml
-	
+
 Or you can have it dump to a file:
 
 	hamlpy inputFile.haml outputFile.html
@@ -133,17 +135,17 @@ Optionally, `--attr-wrapper` can be specified:
 Using the `--jinja` compatibility option adds macro and call tags, and changes the `empty` node in the `for` tag to `else`.
 
 For HamlPy developers, the `-d` switch can be used with `hamlpy` to debug the internal tree structure.
-	
+
 ### Create message files for translation
 
 There is a very simple solution.
 
 	django-admin.py makemessages --settings=<project.settings> -a
-	
+
 Where:
 
   * project.settings -- Django configuration file where  module "hamlpy" is configured properly.
-	
+
 ## Reference
 
 Check out the [reference.md](http://github.com/jessemiller/HamlPy/blob/master/reference.md "HamlPy Reference") file for a complete reference and more examples.

--- a/reference.md
+++ b/reference.md
@@ -40,7 +40,7 @@ Any line that is not interpreted as something else will be taken as plain text a
 	%gee
 		%whiz
 			Wow this is cool!
-			
+
 is compiled to:
 
 	<gee>
@@ -69,7 +69,7 @@ The percent character placed at the beginning of the line will then be followed 
 	%one
 		%two
 			%three Hey there
-			
+
 is compiled to:
 
 	<one>
@@ -85,14 +85,14 @@ Any string is a valid element name and an opening and closing tag will automatic
 Brackets represent a Python dictionary that is used for specifying the attributes of an element.  The dictionary is placed after the tag is defined.  For example:
 
 	%html{'xmlns':'http://www.w3.org/1999/xhtml', 'xml:lang':'en', 'lang':'en'}
-	
+
 is compiled to:
 
 	<html xmlns='http://www.w3.org/1999/xhtml' xml:lang='en' lang='en'></html>
 
 Long attribute dictionaries can be separated into multiple lines:
 
-    %script{'type': 'text/javascript', 'charset': 'utf-8', 
+    %script{'type': 'text/javascript', 'charset': 'utf-8',
             'href': '/long/url/to/javascript/resource.js'}
 
 #### Attributes without values (Boolean attributes)
@@ -111,12 +111,12 @@ is compiled to:
 The 'class' and 'id' attributes can also be specified as a Python tuple whose elements will be joined together.  A 'class' tuple will be joined with " " and an 'id' tuple is joined with "_".  For example:
 
 	%div{'id': ('article', '3'), 'class': ('newest', 'urgent')} Content
-	
+
 is compiled to:
 
 	<div id='article_3' class='newest urgent'>Content</div>
-	
-### Class and ID: . and # 
+
+### Class and ID: . and #
 
 The period and pound sign are borrowed from CSS.  They are used as shortcuts to specify the class and id attributes of an element, respectively.  Multiple class names can be specified by chaining class names together with periods.  They are placed immediately after a tag and before an attribute dictionary.  For example:
 
@@ -124,7 +124,7 @@ The period and pound sign are borrowed from CSS.  They are used as shortcuts to 
 		%span#rice Chicken Fried
 		%p.beans{'food':'true'} The magical fruit
 		%h1#id.class.otherclass La La La
-	
+
 is compiled to:
 
 	<div id='things'>
@@ -132,7 +132,7 @@ is compiled to:
 		<p class='beans' food='true'>The magical fruit</p>
 		<h1 id='id' class='class otherclass'>La La La</h1>
 	</div>
-	
+
 And,
 
 	%div#content
@@ -141,7 +141,7 @@ And,
 			%div.article.date 2006-11-05
 			%div.article.entry
 				Neil Patrick Harris would like to dispel any rumors that he is straight
-				
+
 is compiled to:
 
 	<div id='content'>
@@ -157,19 +157,19 @@ is compiled to:
 These shortcuts can be combined with the attribute dictionary and they will be combined as if they were all put inside a tuple.  For example:
 
 	%div#Article.article.entry{'id':'1', 'class':'visible'} Booyaka
-	
+
 is equivalent to:
-	
+
 	%div{'id':('Article','1'), 'class':('article','entry','visible')} Booyaka
-	
+
 and would compile to:
 
 	<div id='Article_1' class='article entry visible'>Booyaka</div>
-	
+
 You can also use more pythonic array structures in the dictionary, like so:
 
     %div{'id':['Article','1'], 'class':['article','entry','visible']} Booyaka
-	
+
 #### Implicit div elements
 
 Because divs are used so often, they are the default element.  If you only define a class and/or id using `.` or `#` then the %div will be implied.  For example:
@@ -177,7 +177,7 @@ Because divs are used so often, they are the default element.  If you only defin
 	#collection
 		.item
 			.description What a cool item!
-			
+
 will compile to:
 
 	<div id='collection'>
@@ -185,29 +185,29 @@ will compile to:
 			<div class='description'>What a cool item!</div>
 		</div>
 	</div>
-	
+
 ### Self-Closing Tags: /
 
 The forward slash character, when placed at the end of a tag definition, causes the tag to be self-closed.  For example:
 
 	%br/
 	%meta{'http-equiv':'Content-Type', 'content':'text/html'}/
-	
+
 will compile to:
 
 	<br />
 	<meta http-quiv='Content-Type' content='text/html' />
-	
+
 Some tags are automatically closed, as long as they have no content.  `meta, img, link, script, br` and `hr` tags are automatically closed.  For example:
 
 	%br
 	%meta{'http-equiv':'Content-Type', 'content':'text/html'}
-	
+
 will compile to:
 
 	<br />
 	<meta http-quiv='Content-Type' content='text/html' />
-	
+
 ## Comments
 
 There are two types of comments supported:  those that show up in the HTML and those that don't.
@@ -219,21 +219,21 @@ The forward slash character, when placed at the beginning of a line, wraps all t
 	%peanutbutterjelly
 		/ This is the peanutbutterjelly element
 		I like sandwiches!
-		
+
 is compiled to:
 
 	<peanutbutterjelly>
 		<!-- This is the peanutbutterjelly element -->
 		I like sandwiches!
 	</peanutbutterjelly>
-	
+
 The forward slash can also wrap indented sections of code.  For example:
 
 	/
 		%p This doesn't render
 		%div
 			%h1 Because it's commented out!
-			
+
 is compiled to:
 
 	<!--
@@ -242,33 +242,33 @@ is compiled to:
 			<h1>Because it's commented out!</h1>
 		</div>
 	-->
-	
+
 ### Conditional Comments /[]
 
 You can use [Internet Explorer conditional comments](http://www.quirksmode.org/css/condcom.html) by enclosing the condition in square brackets after the /. For example:
 
     /[if IE]
         %h1 Get a better browser
-    
+
 is compiled to:
 
     <!--[if IE]>
         <h1>Get a better browser</h1>
     <![endif]-->
-	
-### HamlPy Comments: -# 
+
+### HamlPy Comments: -#
 
 The hyphen followed immediately by the pound sign signifies a silent comment.  Any text following this isn't rendered during compilation at all.  For example:
 
 	%p foo
 	-# Some comment
 	%p bar
-	
+
 is compiled to:
 
 	<p>foo</p>
 	<p>bar</p>
-	
+
 ## Django Specific Elements
 
 The key difference in HamlPy from Haml is the support for Django elements.  The syntax for ruby evaluation is borrowed from Haml and instead outputs Django tags and variables.
@@ -280,7 +280,7 @@ A line starting with an equal sign followed by a space and then content is evalu
 	.article
 		.preview
 			= story.teaser
-			
+
 is compiled to:
 
 	<div class='article'>
@@ -288,12 +288,12 @@ is compiled to:
 			{{ story.teaser }}
 		</div>
 	</div>
-	
+
 A Django variable can also be used as content for any HTML element by placing an equals sign as the last character before the space and content.  For example:
 
 	%h2
 		%a{'href':'stories/1'}= story.teaser
-		
+
 is compiled to:
 
 	<h2>
@@ -301,7 +301,7 @@ is compiled to:
 	</h2>
 
 ### Inline Django Variables: ={...}
-	
+
 You can also use inline variables by surrounding the variable name with curly braces. For example:
 
 	Hello ={name}, how are you today?
@@ -337,24 +337,24 @@ The hypen character at the start of the line followed by a space and a Django ta
 
 	- block content
 		%h1= section.title
-	
+
 		- for dog in dog_list
 			%h2
 				= dog.name
-	
+
 is compiled to:
 
 	{% block content %}
 		<h1>{{ section.title }}</h1>
-		
+
 		{% for dog in dog_list %}
 			<h2>
 				{{ dog.name }}
 			</h2>
 		{% endfor %}
 	{% endblock %}
-	
-	
+
+
 Notice that block, for, if and else, as well as ifequal, ifnotequal, ifchanged and 'with' are all automatically closed.  Using endfor, endif, endifequal, endifnotequal, endifchanged or endblock will throw an exception.
 
 #### Tags within attributes:
@@ -439,8 +439,8 @@ documentation for more information.
 Execute the filtered text as python and output the result in the file. For example:
 
 	:python
-		for i in range(0, 5): 
-			print "<p>item %s</p>" % i
+		for i in range(0, 5):
+			print("<p>item %s</p>" % i)
 
 is compiled to:
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,49 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# vim: fenc=utf-8
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+#
+
+"""
+File name: setup.py
+Author: dhilipsiva <dhilipsiva@gmail.com>
+Date created: 2015-12-13
+"""
+
+from os import path
 from setuptools import setup
 
-# Note to Jesse - only push sdist to PyPi, bdist seems to always break pip installer
-setup(name='hamlpy',
-      version = '0.82.2',
-      download_url = 'git@github.com:jessemiller/HamlPy.git',
-      packages = ['hamlpy', 'hamlpy.template'],
-      author = 'Jesse Miller',
-      author_email = 'millerjesse@gmail.com',
-      description = 'HAML like syntax for Django templates',
-      keywords = 'haml django converter',
-      url = 'http://github.com/jessemiller/HamlPy',
-      license = 'MIT',
-      install_requires = [
-      ],
-      entry_points = {
-          'console_scripts' : ['hamlpy = hamlpy.hamlpy:convert_files',
-                               'hamlpy-watcher = hamlpy.hamlpy_watcher:watch_folder']
-      }
-    )
+here = path.abspath(path.dirname(__file__))
+f = path.join(here, 'readme.md')
+
+setup(
+    name='HamlPy3',
+    version='0.84.0',
+    packages=['hamlpy', 'hamlpy.template'],
+    author='dhilipsiva',
+    author_email='dhilipsiva@gmail.com',
+    description=(
+        'A python 3 fork & drop-in replacement of HamlPy.'
+        ' HAML like syntax for Django templates'
+    ),
+    keywords='haml django converter',
+    url='http://github.com/appknox/HamlPy3',
+    license='MIT',
+    install_requires=[
+    ],
+    entry_points={
+        'console_scripts': [
+            'hamlpy = hamlpy.hamlpy:convert_files',
+            'hamlpy-watcher = hamlpy.hamlpy_watcher:watch_folder']
+    },
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+    ],
+)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+#
+# test.sh
+# Copyright (C) 2015 dhilipsiva <dhilipsiva@gmail.com>
+#
+# Distributed under terms of the MIT license.
+#
+
+cd hamlpy/test/ && nosetests *.py


### PR DESCRIPTION
I can confirm that this is working on Python 3 & Django 1.8.6. I tried fixing tests. But these errors are popping up when running test.

```
...........F...................F.................F.............................................................
======================================================================
FAIL: test_attr_wrapper (hamlpy.test.hamlpy_test.HamlPyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dhilipsiva/Projects/appknox/HamlPy/hamlpy/test/hamlpy_test.py", line 326, in test_attr_wrapper
    ''')


  1 Fix tests
  2 # Please enter the commit message for your changes. Lines starting
AssertionError: '<html xmlns="http://www.w3.org/1999/xhtml" xml:[184 chars]t>\n' != '<html lang="en" xmlns="http://www.w3.org/1999/x[184 chars]t>\n'
- <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
?                                                         ----------
+ <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
?      ++++++++++
    <body id="main">
      <div class="wrap">
        <a href="/"></a>
      </div>
    </body>
  </html>
  <script type="text/javascript">
  // <![CDATA[
  // ]]>
  </script>


======================================================================
FAIL: test_inline_variables_in_attributes_are_escaped_correctly (hamlpy.test.hamlpy_test.HamlPyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dhilipsiva/Projects/appknox/HamlPy/hamlpy/test/hamlpy_test.py", line 170, in test_inline_variables_in_attributes_are_escaped_correctly
    eq_(html, result)
AssertionError: "<a b='={greeting} test' title='It can\\'t be removed'>blah</a>\n" != "<a title='It can\\'t be removed' b='={greeting} test'>blah</a>\n"

======================================================================
FAIL: test_utf8_with_regular_text (hamlpy.test.hamlpy_test.HamlPyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dhilipsiva/Projects/appknox/HamlPy/hamlpy/test/hamlpy_test.py", line 240, in test_utf8_with_regular_text
    eq_(html, result)
AssertionError: "<a href='' title='\\ub9c1\\ud06c(Korean)'>Some Link</a>\n" != "<a title='링크(Korean)' href=''>Some Link</a>\n"

----------------------------------------------------------------------
Ran 111 tests in 0.047s

FAILED (failures=3)
```
